### PR TITLE
Feature/183 remove embedded tomcat

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore everything
+**
+
+# Allow files and directories
+!/Dockerfile
+!/target/*.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ LABEL \
     name="Hyperdrive Workflow Manager"
 
 ARG WAR_FILE
-COPY ${WAR_FILE} /usr/local/tomcat/webapps/hyperdrive_trigger_war.war
+COPY ${WAR_FILE} /usr/local/tomcat/webapps/hyperdrive_trigger.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+FROM tomcat:9-jdk8-openjdk
 
 LABEL \
     vendor="ABSA" \
@@ -20,10 +20,5 @@ LABEL \
     license="Apache License, version 2.0" \
     name="Hyperdrive Workflow Manager"
 
-ARG JAR_FILE
-COPY ${JAR_FILE} /usr/src/hyperdrive/hyperdrive-trigger.jar
-ENV JAVA_OPTS=""
-WORKDIR /usr/src/hyperdrive
-VOLUME /usr/src/hyperdrive/logs
-EXPOSE 7123
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar hyperdrive-trigger.jar"]
+ARG WAR_FILE
+COPY ${WAR_FILE} /usr/local/tomcat/webapps/hyperdrive_trigger_war.war

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ Event based workflow manager.
 
 # Development
 ## Docker image
-For development purposes, hyperdrive-trigger can be executed as a docker image. This requires a running local docker instance. The provided docker composition consists of the hyperdrive-trigger and a Postgres database. It is currently not possible to start spark-jobs using this docker composition.
+For development purposes, hyperdrive-trigger can be executed as a docker image.
+The provided docker composition consists of one container for the hyperdrive-trigger application and a container for the Postgres database. 
+Additionally, there will be a persistent volume for the database.
+It is currently not possible to start spark-jobs using this docker composition.
 
-To create the docker image, the project has to be built with the `-Pdocker` flag.
+To create the docker image, build the application and create the image using the following command. Please replace `<current_version>` accordingly.
 ```
-mvn clean package -Pdocker
+mvn clean package
+docker build --build-arg WAR_FILE=target/hyperdrive-trigger-<current_version>.war -t absaoss/hyperdrive-trigger .
 ```
 
 To start the application, type
@@ -16,11 +20,9 @@ To start the application, type
 docker-compose up
 ```
 
-This creates one container for hyperdrive-trigger and another container for postgres. Additionally, there will be a shared network and a persistent volume for the database.
-
 Access the application at 
 ```
-http://localhost:7123
+http://localhost:8082/hyperdrive_trigger_war
 ```
 
 To stop the application, type
@@ -36,21 +38,6 @@ docker container prune
 docker volume prune
 ```
 This removes stopped containers and volumes that are not referenced by any containers.
-
-
-### Troubleshooting
-
-#### Error: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-
-If `mvn clean package -Pdocker` fails due to proxy settings, you may want to try to build the image using the docker console.
-
-```
-docker build --build-arg JAR_FILE=target/hyperdrive-trigger-0.0.1-SNAPSHOT.jar -t absaoss/hyperdrive-trigger:latest .
-```
-
-#### Error: hyperdrive-trigger_hyperdrive-trigger_1 exited with code 1
-
-If `docker-compose up` fails with this error message, probably the docker image was not present when `docker-compose up` was called. `docker-compose` tries to build the image by itself, which doesn't work.
 
 ## Testdata
 `mvn test -Ptestdata` creates testdata in `localhost:5432/hyperdriver`, assuming the DB-user `hyperdriver` exists.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker-compose up
 
 Access the application at 
 ```
-http://localhost:8082/hyperdrive_trigger_war
+http://localhost:8082/hyperdrive_trigger
 ```
 
 To stop the application, type

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   postgres_container:
     image: postgres:11
     volumes:
-      - ./target/classes/db_scripts/db_script_v0.sql:/docker-entrypoint-initdb.d/db.sql
+      - ./target/classes/db_scripts/db_script_v1.sql:/docker-entrypoint-initdb.d/db.sql
       - postgres-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=password
@@ -33,7 +33,7 @@ services:
     environment:
       - JAVA_OPTS=-Ddb.user=postgres -Ddb.url=jdbc:postgresql://postgres_container:5432/testdb -Ddb.password=password
     ports:
-      - 7123:7123
+      - 8082:8080
 
 volumes:
   postgres-data:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <groupId>za.co.absa</groupId>
     <artifactId>hyperdrive-trigger</artifactId>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -47,7 +47,6 @@
         <webjars.locator.version>0.35</webjars.locator.version>
         <spring.version>2.0.0.RELEASE</spring.version>
         <quartz.version>2.3.2</quartz.version>
-        <maven.war.version>2.2</maven.war.version>
         <log4j.version>2.11.1</log4j.version>
         <slf4j.log4j2.version>1.7.26</slf4j.log4j2.version>
         <spring.ldap.version>5.0.3.RELEASE</spring.ldap.version>
@@ -64,7 +63,7 @@
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <frontend.maven.plugin.version>1.9.0</frontend.maven.plugin.version>
-
+        <maven.war.plugin.version>2.6</maven.war.plugin.version>
 
         <skip.docker>true</skip.docker>
         <skipNpmTests>${skipTests}</skipNpmTests>
@@ -147,6 +146,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <version>${spring-boot-starter-tomcat.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -291,6 +291,27 @@
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>
                     <noCache>true</noCache>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven.war.plugin.version}</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <webResources>
+                        <resource>
+                            <directory>target/classes/ui</directory>
+                            <targetPath>/</targetPath>
+                            <filtering>false</filtering>
+                        </resource>
+                    </webResources>
+                    <packagingExcludes>META-INF/*.SF, META-INF/*.DSA, META-INF/*.RSA</packagingExcludes>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,9 @@
         <maven.ant.plugin.version>1.8</maven.ant.plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
-        <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <frontend.maven.plugin.version>1.9.0</frontend.maven.plugin.version>
         <maven.war.plugin.version>2.6</maven.war.plugin.version>
 
-        <skip.docker>true</skip.docker>
         <skipNpmTests>${skipTests}</skipNpmTests>
         <scalatest.suites/>
         <scalatest.tagsToExclude>za.co.absa.hyperdrive.trigger.testdata.PersistingData</scalatest.tagsToExclude>
@@ -271,29 +269,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${dockerfile-maven.version}</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>push</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skip>${skip.docker}</skip>
-                    <repository>absaoss/hyperdrive-trigger</repository>
-                    <tag>latest</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                    <noCache>true</noCache>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${maven.war.plugin.version}</version>
@@ -374,12 +349,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>docker</id>
-            <properties>
-                <skip.docker>false</skip.docker>
-            </properties>
-        </profile>
         <profile>
             <id>testdata</id>
             <properties>

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/Application.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/Application.scala
@@ -85,8 +85,3 @@ class Application() {
   }
 
 }
-
-object Application extends App {
-  val context = SpringApplication.run(classOf[Application], args: _*)
-  context.getBean(classOf[HyperDriverManager]).startManager
-}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/HyperDriverManager.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/HyperDriverManager.scala
@@ -15,6 +15,7 @@
 
 package za.co.absa.hyperdrive.trigger
 
+import javax.annotation.PostConstruct
 import javax.inject.Inject
 import org.springframework.stereotype.Component
 import za.co.absa.hyperdrive.trigger.scheduler.JobScheduler
@@ -23,12 +24,17 @@ import scala.concurrent.Future
 
 @Component
 class HyperDriverManager @Inject() (jobScheduler: JobScheduler) {
-  
+
+  @PostConstruct
+  def init(): Unit = {
+    startManager()
+  }
+
   def isManagerRunning: Boolean = {
     jobScheduler.isManagerRunning
   }
 
-  def startManager: Unit = {
+  def startManager(): Unit = {
     jobScheduler.startManager()
   }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --aot --open --base-href /hyperdrive_trigger_war/ --deploy-url /hyperdrive_trigger_war/",
-    "build": "ng build --aot --prod --base-href /hyperdrive_trigger_war/",
+    "start": "ng serve --aot --open --base-href /hyperdrive_trigger/ --deploy-url /hyperdrive_trigger/",
+    "build": "ng build --aot --prod --base-href /hyperdrive_trigger/",
     "test": "ng test",
     "test:ci": "ng test --karmaConfig=karma.conf.ci.js",
     "lint": "tsc --noEmit && eslint 'src/**/*.{js,ts}' --quiet --fix",

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --aot",
-    "build": "ng build --aot --prod",
+    "start": "ng serve --aot --open --base-href /hyperdrive_trigger_war/ --deploy-url /hyperdrive_trigger_war/",
+    "build": "ng build --aot --prod --base-href /hyperdrive_trigger_war/",
     "test": "ng test",
     "test:ci": "ng test --karmaConfig=karma.conf.ci.js",
     "lint": "tsc --noEmit && eslint 'src/**/*.{js,ts}' --quiet --fix",

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -63,6 +63,7 @@ import { PreviousRouteService } from './services/previousRoute/previous-route.se
 import { ToastrModule } from 'ngx-toastr';
 import { ConfirmationDialogComponent } from './components/common/confirmation-dialog/confirmation-dialog.component';
 import { CronQuartzExpressionValidator } from './components/workflows/workflow/dynamic-parts/cron-quartz-part/validator/cron-quartz-expression.validator';
+import { BaseUrlInterceptor } from './services/interceptors/baseurl.interceptor';
 
 @NgModule({
   declarations: [
@@ -113,6 +114,7 @@ import { CronQuartzExpressionValidator } from './components/workflows/workflow/d
     LogInGuardService,
     PreviousRouteService,
     { provide: HTTP_INTERCEPTORS, useClass: CsrfInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: BaseUrlInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
   ],
   bootstrap: [AppComponent],

--- a/ui/src/app/services/interceptors/baseurl.interceptor.ts
+++ b/ui/src/app/services/interceptors/baseurl.interceptor.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class BaseUrlInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    let baseUrl = window.location.pathname;
+    if (baseUrl[baseUrl.length - 1] === '/' && req.url[0] === '/') {
+      baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+    } else if (baseUrl[baseUrl.length - 1] !== '/' && req.url[0] !== '/') {
+      baseUrl = baseUrl + '/';
+    }
+    const apiReq = req.clone({ url: `${baseUrl}${req.url}` });
+    return next.handle(apiReq);
+  }
+}

--- a/ui/src/proxy.conf.json
+++ b/ui/src/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/": {
-    "target": "http://localhost:7123",
+    "target": "http://localhost:8080",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "info"


### PR DESCRIPTION
Closes #183 

**How to test**
Please follow the screenshots in #183 to configure the tomcat run config in IntelliJ.
- Production Mode: `mvn clean package` and open http://localhost:8080/hyperdrive_trigger
- Dev Mode: Start tomcat with IntelliJ, `cd ui && npm start`, should open browser in http://localhost:4200/hyperdrive_trigger
- Docker: Follow instructions in readme

**Comments**
Why merge into release/0.1.0. We still need to maintain old style with embedded tomcat until vm with external tomcat can be rolled out, so we shouldn't merge into develop until then.