### PR TITLE
Workflows side navigation hidden text fix

### DIFF
--- a/ui/src/app/components/workflows/workflows.component.scss
+++ b/ui/src/app/components/workflows/workflows.component.scss
@@ -29,5 +29,9 @@
 }
 
 .sidenav {
-  width: min-content;
+  word-wrap: break-word;
+}
+
+.sidenav-content {
+  padding-right: 0.3rem
 }


### PR DESCRIPTION
Implements: #193 
Solution: 
Line breaks in text. So whole text is always visible. 