### PR TITLE
keep workflow screen filters on runs screen

### DIFF
--- a/ui/src/app/components/runs/runs.component.html
+++ b/ui/src/app/components/runs/runs.component.html
@@ -33,10 +33,12 @@
       </div>
     </clr-dg-action-bar>
 
-    <clr-dg-column [clrDgField]="dagRunColumns.WORKFLOW_NAME" [clrFilterValue]>
+    <clr-dg-column [clrDgField]="dagRunColumns.WORKFLOW_NAME">
       <ng-container *clrDgHideableColumn="{hidden: false}">Workflow name</ng-container>
       <clr-dg-filter [clrDgFilter]="workflowNameFilter">
-        <app-string-filter #workflowNameFilter [property]="dagRunColumns.WORKFLOW_NAME"
+        <app-string-filter [value]="getWorkflowFilter()"
+                           #workflowNameFilter
+                           [property]="dagRunColumns.WORKFLOW_NAME"
                            [removeFiltersSubject]="removeFiltersSubject">
         </app-string-filter>
       </clr-dg-filter>
@@ -44,7 +46,9 @@
     <clr-dg-column [clrDgField]="dagRunColumns.PROJECT_NAME">
       <ng-container *clrDgHideableColumn="{hidden: false}">Project name</ng-container>
       <clr-dg-filter [clrDgFilter]="projectNameFilter">
-        <app-string-filter #projectNameFilter [property]="dagRunColumns.PROJECT_NAME"
+        <app-string-filter [value]="getProjectFilter()"
+                           #projectNameFilter 
+                           [property]="dagRunColumns.PROJECT_NAME"
                            [removeFiltersSubject]="removeFiltersSubject">
         </app-string-filter>
       </clr-dg-filter>

--- a/ui/src/app/components/runs/runs.component.ts
+++ b/ui/src/app/components/runs/runs.component.ts
@@ -30,6 +30,7 @@ import { IntRangeFilterAttributes } from '../../models/search/intRangeFilterAttr
 import { DateTimeRangeFilterAttributes } from '../../models/search/dateTimeRangeFilterAttributes.model';
 import { SortAttributesModel } from '../../models/search/sortAttributes.model';
 import { EqualsMultipleFilterAttributes } from '../../models/search/equalsMultipleFilterAttributes.model';
+import { DatagridService } from '../../services/datagrid/datagrid.service';
 
 @Component({
   selector: 'app-runs',
@@ -45,6 +46,9 @@ export class RunsComponent implements OnDestroy, AfterViewInit {
   pageSize = 0;
   sort: SortAttributesModel = null;
 
+  workflowFilter: any;
+  projectFilter: any;
+
   dagRuns: DagRunModel[] = [];
   total = 0;
   loading = true;
@@ -56,7 +60,7 @@ export class RunsComponent implements OnDestroy, AfterViewInit {
 
   removeFiltersSubject: Subject<any> = new Subject();
 
-  constructor(private store: Store<AppState>) {
+  constructor(private store: Store<AppState>, private datagrid: DatagridService) {
     // do nothing
   }
 
@@ -96,6 +100,22 @@ export class RunsComponent implements OnDestroy, AfterViewInit {
     };
 
     this.store.dispatch(new GetDagRuns(searchRequestModel));
+  }
+
+  getWorkflowFilter(): string | any {
+    this.datagrid.getWorkflowFilter().subscribe((value) => {
+      this.workflowFilter = value;
+    });
+
+    return this.workflowFilter ? this.workflowFilter : undefined;
+  }
+
+  getProjectFilter(): string | any {
+    this.datagrid.getProjectFilter().subscribe((value) => {
+      this.projectFilter = value;
+    });
+
+    return this.projectFilter ? this.projectFilter : undefined;
   }
 
   clearFilters() {

--- a/ui/src/app/components/workflows/workflows-home/workflows-home.component.ts
+++ b/ui/src/app/components/workflows/workflows-home/workflows-home.component.ts
@@ -29,6 +29,7 @@ import { ClrDatagridColumn, ClrDatagridStateInterface } from '@clr/angular';
 import { SortAttributesModel } from '../../../models/search/sortAttributes.model';
 import { filter } from 'rxjs/operators';
 import { workflowsHomeColumns } from 'src/app/constants/workflow.constants';
+import { DatagridService } from '../../../services/datagrid/datagrid.service';
 
 @Component({
   selector: 'app-workflows-home',
@@ -51,7 +52,12 @@ export class WorkflowsHomeComponent implements OnInit, OnDestroy {
   filters: any[] = undefined;
   ignoreRefresh = false;
 
-  constructor(private store: Store<AppState>, private confirmationDialogService: ConfirmationDialogService, private router: Router) {
+  constructor(
+    private store: Store<AppState>,
+    private confirmationDialogService: ConfirmationDialogService,
+    private router: Router,
+    private datagrid: DatagridService,
+  ) {
     this.routerSubscription = router.events.pipe(filter((e) => e instanceof ResolveEnd)).subscribe((e: ResolveEnd) => {
       this.ignoreRefresh = e.state.root.component !== WorkflowsHomeComponent;
     });
@@ -108,6 +114,8 @@ export class WorkflowsHomeComponent implements OnInit, OnDestroy {
       this.store.dispatch(new SetWorkflowsSort(this.sort));
       this.filters = state.filters ? state.filters : [];
       this.store.dispatch(new SetWorkflowsFilters(this.filters));
+      this.datagrid.changeWorkflowFilter(this.getFilter(this.workflowsHomeColumns.WORKFLOW_NAME));
+      this.datagrid.changeProjectFilter(this.getFilter(this.workflowsHomeColumns.PROJECT_NAME));
     }
   }
 

--- a/ui/src/app/services/datagrid/datagrid.service.spec.ts
+++ b/ui/src/app/services/datagrid/datagrid.service.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { DatagridService } from './datagrid.service';
+
+describe('DatagridService', () => {
+  let service: DatagridService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DatagridService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/ui/src/app/services/datagrid/datagrid.service.ts
+++ b/ui/src/app/services/datagrid/datagrid.service.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DatagridService {
+  private workflowFilter = new BehaviorSubject(undefined);
+  private projectFilter = new BehaviorSubject(undefined);
+
+  constructor() {
+    // do nothing
+  }
+
+  changeWorkflowFilter(value: string) {
+    this.workflowFilter.next(value);
+  }
+
+  changeProjectFilter(value: string) {
+    this.projectFilter.next(value);
+  }
+
+  getWorkflowFilter(): Observable<string> {
+    return this.workflowFilter.asObservable();
+  }
+
+  getProjectFilter(): Observable<string> {
+    return this.projectFilter.asObservable();
+  }
+}


### PR DESCRIPTION
resolves #21 

**NB**
There’s an 'error/exception' when clearing the filters from the runs screen. 
1. [HPM] Error occurred while trying to proxy request ... -- front-end
2. org.apache.catalina.connector.ClientAbortException: java.io.IOException: Broken pipe -- back-end

did a bit of research can’t seem to pinpoint the root cause.