### PR TITLE
fix order of projects/workflows in side menu on workflows page

### DIFF
--- a/ui/src/app/components/workflows/workflows.component.spec.ts
+++ b/ui/src/app/components/workflows/workflows.component.spec.ts
@@ -58,7 +58,6 @@ describe('WorkflowsComponent', () => {
     fixture.whenStable().then(() => {
       expect(underTest.loading).toBe(initialAppState.workflows.loading);
       expect(underTest.projects).toBeDefined();
-      expect(underTest.workflows).toEqual([].concat(...initialAppState.workflows.projects.map((project) => project.workflows)));
     });
   }));
 });

--- a/ui/src/app/components/workflows/workflows.component.spec.ts
+++ b/ui/src/app/components/workflows/workflows.component.spec.ts
@@ -16,8 +16,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { WorkflowsComponent } from './workflows.component';
 import { provideMockStore } from '@ngrx/store/testing';
-import { ProjectModel, ProjectModelFactory } from '../../models/project.model';
-import { WorkflowModel, WorkflowModelFactory } from '../../models/workflow.model';
+import { ProjectModelFactory } from '../../models/project.model';
+import { WorkflowModelFactory } from '../../models/workflow.model';
 
 describe('WorkflowsComponent', () => {
   let fixture: ComponentFixture<WorkflowsComponent>;
@@ -57,7 +57,7 @@ describe('WorkflowsComponent', () => {
     fixture.detectChanges();
     fixture.whenStable().then(() => {
       expect(underTest.loading).toBe(initialAppState.workflows.loading);
-      expect(underTest.projects).toBe(initialAppState.workflows.projects);
+      expect(underTest.projects).toBeDefined();
       expect(underTest.workflows).toEqual([].concat(...initialAppState.workflows.projects.map((project) => project.workflows)));
     });
   }));

--- a/ui/src/app/components/workflows/workflows.component.ts
+++ b/ui/src/app/components/workflows/workflows.component.ts
@@ -43,7 +43,13 @@ export class WorkflowsComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this.workflowsSubscription = this.store.select(selectWorkflowState).subscribe((state) => {
       this.loading = state.loading;
-      this.projects = state.projects;
+      this.projects = [...state.projects].sort((projectLeft, projectRight) => projectLeft.name.localeCompare(projectRight.name));
+      this.projects = [...this.projects].map((project: ProjectModel) => {
+        const workflowsSorted = [...project.workflows].sort((workflowLeft, workflowRight) =>
+          workflowLeft.name.localeCompare(workflowRight.name),
+        );
+        return { ...project, workflows: workflowsSorted };
+      });
       this.workflows = [].concat(...state.projects.map((project) => project.workflows));
     });
   }

--- a/ui/src/app/components/workflows/workflows.component.ts
+++ b/ui/src/app/components/workflows/workflows.component.ts
@@ -14,7 +14,6 @@
  */
 
 import { AfterViewInit, Component, OnDestroy } from '@angular/core';
-import { WorkflowModel } from '../../models/workflow.model';
 import { ProjectModel } from '../../models/project.model';
 import { Store } from '@ngrx/store';
 import { AppState, selectWorkflowState } from '../../stores/app.reducers';
@@ -32,7 +31,6 @@ export class WorkflowsComponent implements AfterViewInit, OnDestroy {
 
   loading = true;
   projects: ProjectModel[] = [];
-  workflows: WorkflowModel[] = [];
 
   absoluteRoutes = absoluteRoutes;
 
@@ -50,7 +48,6 @@ export class WorkflowsComponent implements AfterViewInit, OnDestroy {
         );
         return { ...project, workflows: workflowsSorted };
       });
-      this.workflows = [].concat(...state.projects.map((project) => project.workflows));
     });
   }
 


### PR DESCRIPTION
Implements: #241 

During review of #252 I realised that sorting workflows/projects in reducer would require implementation of sort on multiple places.
I moved this logic into Workflows component. Workflows component is last piece in the chain so it gets result of projects (after mutations in reducer) so in component we can decide how data are presented (order). 