### PR TITLE
Fix/267 runs details refresh

### DIFF
--- a/ui/src/app/components/runs/run-detail/run-detail.component.ts
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnDestroy, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { jobStatuses } from '../../../models/enums/jobStatuses.constants';
 import { JobInstanceModel } from '../../../models/jobInstance.model';
 import { Store } from '@ngrx/store';
@@ -30,6 +30,7 @@ export class RunDetailComponent implements OnInit, OnDestroy {
   @Input('dagRunId') dagRunId: number;
   @Input() refreshSubject: Subject<boolean> = new Subject<boolean>();
   runDetailSubscription: Subscription;
+  refreshSubscription: Subscription;
 
   jobInstances: JobInstanceModel[];
   loading = true;
@@ -45,18 +46,20 @@ export class RunDetailComponent implements OnInit, OnDestroy {
       this.loading = state.detail.loading;
       this.jobInstances = state.detail.jobInstances;
     });
-    this.onRefresh();
-  }
 
-  onRefresh() {
-    this.refreshSubject.subscribe((response) => {
+    this.refreshSubscription = this.refreshSubject.subscribe((response) => {
       if (response) {
-        this.store.dispatch(new GetDagRunDetail(this.dagRunId));
+        this.onRefresh();
       }
     });
   }
 
+  onRefresh() {
+    this.store.dispatch(new GetDagRunDetail(this.dagRunId));
+  }
+
   ngOnDestroy(): void {
     !!this.runDetailSubscription && this.runDetailSubscription.unsubscribe();
+    !!this.refreshSubscription && this.refreshSubscription.unsubscribe();
   }
 }

--- a/ui/src/app/components/runs/run-detail/run-detail.component.ts
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { jobStatuses } from '../../../models/enums/jobStatuses.constants';
 import { JobInstanceModel } from '../../../models/jobInstance.model';
 import { Store } from '@ngrx/store';
@@ -26,8 +26,9 @@ import { Subscription } from 'rxjs';
   templateUrl: './run-detail.component.html',
   styleUrls: ['./run-detail.component.scss'],
 })
-export class RunDetailComponent implements OnInit, OnDestroy {
+export class RunDetailComponent implements OnInit, OnDestroy, OnChanges {
   @Input('dagRunId') dagRunId: number;
+  @Input('jobStatus') jobStatus: string;
   runDetailSubscription: Subscription;
 
   jobInstances: JobInstanceModel[];
@@ -44,6 +45,10 @@ export class RunDetailComponent implements OnInit, OnDestroy {
       this.loading = state.detail.loading;
       this.jobInstances = state.detail.jobInstances;
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+   // so nothing
   }
 
   ngOnDestroy(): void {

--- a/ui/src/app/components/runs/run-detail/run-detail.component.ts
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.ts
@@ -19,16 +19,16 @@ import { JobInstanceModel } from '../../../models/jobInstance.model';
 import { Store } from '@ngrx/store';
 import { AppState, selectRunState } from '../../../stores/app.reducers';
 import { GetDagRunDetail } from '../../../stores/runs/runs.actions';
-import { Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-run-detail',
   templateUrl: './run-detail.component.html',
   styleUrls: ['./run-detail.component.scss'],
 })
-export class RunDetailComponent implements OnInit, OnDestroy, OnChanges {
+export class RunDetailComponent implements OnInit, OnDestroy {
   @Input('dagRunId') dagRunId: number;
-  @Input('jobStatus') jobStatus: string;
+  @Input() refreshSubject: Subject<boolean> = new Subject<boolean>();
   runDetailSubscription: Subscription;
 
   jobInstances: JobInstanceModel[];
@@ -45,10 +45,15 @@ export class RunDetailComponent implements OnInit, OnDestroy, OnChanges {
       this.loading = state.detail.loading;
       this.jobInstances = state.detail.jobInstances;
     });
+    this.onRefresh();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-   // so nothing
+  onRefresh() {
+    this.refreshSubject.subscribe((response) => {
+      if (response) {
+        this.store.dispatch(new GetDagRunDetail(this.dagRunId));
+      }
+    });
   }
 
   ngOnDestroy(): void {

--- a/ui/src/app/components/runs/runs.component.html
+++ b/ui/src/app/components/runs/runs.component.html
@@ -130,7 +130,7 @@
         <b>Status: </b>{{detail.status}}
       </clr-dg-detail-header>
       <clr-dg-detail-body>
-        <app-run-detail [dagRunId]="detail.id" [jobStatus]="detail.status"></app-run-detail>
+        <app-run-detail [dagRunId]="detail.id" [refreshSubject]="refreshSubject.asObservable()"></app-run-detail>
       </clr-dg-detail-body>
     </clr-dg-detail>
 

--- a/ui/src/app/components/runs/runs.component.html
+++ b/ui/src/app/components/runs/runs.component.html
@@ -130,7 +130,7 @@
         <b>Status: </b>{{detail.status}}
       </clr-dg-detail-header>
       <clr-dg-detail-body>
-        <app-run-detail [dagRunId]="detail.id"></app-run-detail>
+        <app-run-detail [dagRunId]="detail.id" [jobStatus]="detail.status"></app-run-detail>
       </clr-dg-detail-body>
     </clr-dg-detail>
 

--- a/ui/src/app/components/runs/runs.component.html
+++ b/ui/src/app/components/runs/runs.component.html
@@ -130,7 +130,7 @@
         <b>Status: </b>{{detail.status}}
       </clr-dg-detail-header>
       <clr-dg-detail-body>
-        <app-run-detail [dagRunId]="detail.id" [refreshSubject]="refreshSubject.asObservable()"></app-run-detail>
+        <app-run-detail [dagRunId]="detail.id" [refreshSubject]="refreshSubject"></app-run-detail>
       </clr-dg-detail-body>
     </clr-dg-detail>
 

--- a/ui/src/app/components/runs/runs.component.ts
+++ b/ui/src/app/components/runs/runs.component.ts
@@ -61,6 +61,7 @@ export class RunsComponent implements OnDestroy, AfterViewInit {
   descSort = ClrDatagridSortOrder.DESC;
 
   removeFiltersSubject: Subject<any> = new Subject();
+  refreshSubject: Subject<boolean> = new Subject<boolean>();
 
   constructor(private store: Store<AppState>, route: ActivatedRoute) {
     this.paramsSubscription = route.params.subscribe((parameters) => {
@@ -106,6 +107,7 @@ export class RunsComponent implements OnDestroy, AfterViewInit {
     };
 
     this.store.dispatch(new GetDagRuns(searchRequestModel));
+    this.refreshSubject.next(true);
   }
 
   clearFilters() {


### PR DESCRIPTION
Implements #267 

**How to Test:** 
Within your workflow, create Shell jobs that point to your local bash script, allow the jobs to have some running time in between. While the first job is running keeping refreshing the run-detail screen.
1. job 1 running, job 2 in queue.
2. job 1 fails/succeeds, job two running.
3. both jobs with final status.