### PR TITLE
Add hyperconf template

### DIFF
--- a/src/main/resources/db_scripts/db_script_v5.sql
+++ b/src/main/resources/db_scripts/db_script_v5.sql
@@ -157,7 +157,7 @@ left join workflow
     on workflow.id = dag_instance.workflow_id;
 
 create table "job_template" (
-  "name" VARCHAR NOT NULL,
+  "name" VARCHAR NOT NULL UNIQUE,
   "job_type" VARCHAR NOT NULL,
   "variables" VARCHAR NOT NULL,
   "maps" VARCHAR NOT NULL,

--- a/src/main/resources/db_scripts/db_script_v5.sql
+++ b/src/main/resources/db_scripts/db_script_v5.sql
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+create table "workflow" (
+  "name" VARCHAR(45) NOT NULL UNIQUE,
+  "is_active" BOOLEAN NOT NULL,
+  "project" VARCHAR NOT NULL,
+  "created" TIMESTAMP NOT NULL,
+  "updated" TIMESTAMP,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "job_instance" (
+  "job_name" VARCHAR NOT NULL,
+  "job_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "job_status" VARCHAR NOT NULL,
+  "executor_job_id" VARCHAR,
+  "created" TIMESTAMP NOT NULL,
+  "updated" TIMESTAMP,
+  "order" INTEGER NOT NULL,
+  "dag_instance_id" BIGINT NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "job_definition" (
+  "dag_definition_id" BIGINT NOT NULL,
+  "job_template_id" BIGINT NOT NULL,
+  "name" VARCHAR NOT NULL,
+  "deprecated_job_type" VARCHAR,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "order" INTEGER NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "sensor" (
+  "workflow_id" BIGINT NOT NULL,
+  "sensor_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "match_properties" VARCHAR NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "event" (
+  "sensor_event_id" VARCHAR(70) NOT NULL UNIQUE,
+  "sensor_id" BIGINT NOT NULL,
+  "payload" VARCHAR NOT NULL,
+  "dag_instance_id" BIGINT,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "dag_definition" (
+  "workflow_id" BIGINT NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "dag_instance" (
+  "status" VARCHAR NOT NULL,
+  "workflow_id" BIGINT NOT NULL,
+  "started" TIMESTAMP NOT NULL,
+  "finished" TIMESTAMP,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "workflow_history" (
+  "id" BIGSERIAL NOT NULL PRIMARY KEY,
+  "changed_on" TIMESTAMP NOT NULL,
+  "changed_by" VARCHAR NOT NULL,
+  "operation" VARCHAR NOT NULL,
+  "workflow_id" BIGINT NOT NULL,
+  "workflow" VARCHAR NOT NULL
+);
+
+alter table "job_instance"
+  add constraint "job_instance_dag_instance_fk"
+  foreign key("dag_instance_id")
+  references "dag_instance"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "job_definition"
+  add constraint "job_definition_dag_definition_fk"
+  foreign key("dag_definition_id")
+  references "dag_definition"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "job_definition"
+add constraint "job_definition_job_template_fk"
+foreign key("job_template_id")
+references "job_template"("id")
+on update NO ACTION on delete NO ACTION;
+
+alter table "sensor"
+  add constraint "sensor_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "event"
+  add constraint "event_dag_instance_fk"
+  foreign key("dag_instance_id")
+  references "dag_instance"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "event"
+  add constraint "event_sensor_fk"
+  foreign key("sensor_id")
+  references "sensor"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "dag_definition"
+  add constraint "dag_definition_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "dag_instance"
+  add constraint "dag_instance_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+create view "dag_run_view" AS
+select
+    dag_instance.id as "id",
+    workflow.name as "workflow_name",
+    workflow.project as "project_name",
+    COALESCE(jobInstanceCount.count, 0) as "job_count",
+    dag_instance.started as "started",
+    dag_instance.finished as "finished",
+    dag_instance.status as "status",
+    workflow.id as "workflow_id"
+from dag_instance
+left join (
+    select job_instance.dag_instance_id, count(1) as "count"
+    from job_instance
+    group by dag_instance_id
+) as jobInstanceCount
+    on jobInstanceCount.dag_instance_id = dag_instance.id
+left join workflow
+    on workflow.id = dag_instance.workflow_id;
+
+create table "job_template" (
+  "name" VARCHAR NOT NULL,
+  "job_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Spark Job', 'Spark', '{}', '{}', '{}');
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Shell Job', 'Shell', '{}', '{}', '{}');

--- a/src/main/resources/db_scripts/db_script_v6.sql
+++ b/src/main/resources/db_scripts/db_script_v6.sql
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+create table "workflow" (
+  "name" VARCHAR(45) NOT NULL UNIQUE,
+  "is_active" BOOLEAN NOT NULL,
+  "project" VARCHAR NOT NULL,
+  "created" TIMESTAMP NOT NULL,
+  "updated" TIMESTAMP,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "job_instance" (
+  "job_name" VARCHAR NOT NULL,
+  "job_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "job_status" VARCHAR NOT NULL,
+  "executor_job_id" VARCHAR,
+  "created" TIMESTAMP NOT NULL,
+  "updated" TIMESTAMP,
+  "order" INTEGER NOT NULL,
+  "dag_instance_id" BIGINT NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "job_definition" (
+  "dag_definition_id" BIGINT NOT NULL,
+  "job_template_id" BIGINT NOT NULL,
+  "name" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "order" INTEGER NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "sensor" (
+  "workflow_id" BIGINT NOT NULL,
+  "sensor_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "match_properties" VARCHAR NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "event" (
+  "sensor_event_id" VARCHAR(70) NOT NULL UNIQUE,
+  "sensor_id" BIGINT NOT NULL,
+  "payload" VARCHAR NOT NULL,
+  "dag_instance_id" BIGINT,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "dag_definition" (
+  "workflow_id" BIGINT NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "dag_instance" (
+  "status" VARCHAR NOT NULL,
+  "workflow_id" BIGINT NOT NULL,
+  "started" TIMESTAMP NOT NULL,
+  "finished" TIMESTAMP,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+create table "workflow_history" (
+  "id" BIGSERIAL NOT NULL PRIMARY KEY,
+  "changed_on" TIMESTAMP NOT NULL,
+  "changed_by" VARCHAR NOT NULL,
+  "operation" VARCHAR NOT NULL,
+  "workflow_id" BIGINT NOT NULL,
+  "workflow" VARCHAR NOT NULL
+);
+
+alter table "job_instance"
+  add constraint "job_instance_dag_instance_fk"
+  foreign key("dag_instance_id")
+  references "dag_instance"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "job_definition"
+  add constraint "job_definition_dag_definition_fk"
+  foreign key("dag_definition_id")
+  references "dag_definition"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "job_definition"
+add constraint "job_definition_job_template_fk"
+foreign key("job_template_id")
+references "job_template"("id")
+on update NO ACTION on delete NO ACTION;
+
+alter table "sensor"
+  add constraint "sensor_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "event"
+  add constraint "event_dag_instance_fk"
+  foreign key("dag_instance_id")
+  references "dag_instance"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "event"
+  add constraint "event_sensor_fk"
+  foreign key("sensor_id")
+  references "sensor"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "dag_definition"
+  add constraint "dag_definition_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+alter table "dag_instance"
+  add constraint "dag_instance_workflow_fk"
+  foreign key("workflow_id")
+  references "workflow"("id")
+  on update NO ACTION on delete NO ACTION;
+
+create view "dag_run_view" AS
+select
+    dag_instance.id as "id",
+    workflow.name as "workflow_name",
+    workflow.project as "project_name",
+    COALESCE(jobInstanceCount.count, 0) as "job_count",
+    dag_instance.started as "started",
+    dag_instance.finished as "finished",
+    dag_instance.status as "status",
+    workflow.id as "workflow_id"
+from dag_instance
+left join (
+    select job_instance.dag_instance_id, count(1) as "count"
+    from job_instance
+    group by dag_instance_id
+) as jobInstanceCount
+    on jobInstanceCount.dag_instance_id = dag_instance.id
+left join workflow
+    on workflow.id = dag_instance.workflow_id;
+
+create table "job_template" (
+  "name" VARCHAR NOT NULL,
+  "job_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);
+
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Spark Job', 'Spark', '{}', '{}', '{}');
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Shell Job', 'Shell', '{}', '{}', '{}');

--- a/src/main/resources/db_scripts/db_script_v6.sql
+++ b/src/main/resources/db_scripts/db_script_v6.sql
@@ -156,7 +156,7 @@ left join workflow
     on workflow.id = dag_instance.workflow_id;
 
 create table "job_template" (
-  "name" VARCHAR NOT NULL,
+  "name" VARCHAR NOT NULL UNIQUE,
   "job_type" VARCHAR NOT NULL,
   "variables" VARCHAR NOT NULL,
   "maps" VARCHAR NOT NULL,

--- a/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
+++ b/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+create table "job_template" (
+  "name" VARCHAR NOT NULL,
+  "job_type" VARCHAR NOT NULL,
+  "variables" VARCHAR NOT NULL,
+  "maps" VARCHAR NOT NULL,
+  "key_value_pairs" VARCHAR NOT NULL,
+  "id" BIGSERIAL NOT NULL PRIMARY KEY
+);

--- a/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
+++ b/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
@@ -21,3 +21,29 @@ create table "job_template" (
   "key_value_pairs" VARCHAR NOT NULL,
   "id" BIGSERIAL NOT NULL PRIMARY KEY
 );
+
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Spark Job', 'Spark', '{}', '{}', '{}');
+insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
+values ('Generic Shell Job', 'Shell', '{}', '{}', '{}');
+
+alter table "job_definition"
+add "job_template_id" BIGINT;
+
+alter table "job_definition"
+add constraint "job_definition_job_template_fk"
+foreign key("job_template_id")
+references "job_template"("id")
+on update NO ACTION on delete NO ACTION;
+
+update "job_definition" set "job_template_id" = (select id from job_template where name = 'Generic Spark Job')
+where "job_type" = 'Spark';
+update "job_definition" set "job_template_id" = (select id from job_template where name = 'Generic Shell Job')
+where "job_type" = 'Shell';
+
+alter table "job_definition"
+alter column "job_template_id" SET NOT NULL;
+
+-- delete later to enable simple rollback
+alter table "job_definition"
+rename column "job_type" to "deprecated_job_type"

--- a/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
+++ b/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
@@ -47,3 +47,6 @@ alter column "job_template_id" SET NOT NULL;
 -- delete later to enable simple rollback
 alter table "job_definition"
 rename column "job_type" to "deprecated_job_type"
+
+alter table "job_definition"
+alter column "deprecated_job_type" drop not null;

--- a/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
+++ b/src/main/resources/db_scripts/delta_script_v4_to_v5.sql
@@ -14,7 +14,7 @@
  */
 
 create table "job_template" (
-  "name" VARCHAR NOT NULL,
+  "name" VARCHAR NOT NULL UNIQUE,
   "job_type" VARCHAR NOT NULL,
   "variables" VARCHAR NOT NULL,
   "maps" VARCHAR NOT NULL,

--- a/src/main/resources/db_scripts/delta_script_v5_to_v6.sql
+++ b/src/main/resources/db_scripts/delta_script_v5_to_v6.sql
@@ -13,17 +13,6 @@
  * limitations under the License.
  */
 
-package za.co.absa.hyperdrive.trigger.models
 
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
-
-case class JobDefinition(
-  dagDefinitionId: Long = 0,
-  jobTemplateId: Long = 0,
-  name: String,
-  jobType: JobType,
-  jobParameters: JobParameters,
-  order: Int,
-  id: Long = 0
-)
-
+alter table "job_definition"
+drop column "deprecated_job_type"

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobTemplateController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobTemplateController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.controllers
+
+import java.util.concurrent.CompletableFuture
+
+import javax.inject.Inject
+import org.springframework.web.bind.annotation._
+import za.co.absa.hyperdrive.trigger.api.rest.services.{JobInstanceService, JobTemplateService}
+import za.co.absa.hyperdrive.trigger.models.JobInstance
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@RestController
+class JobTemplateController @Inject()(jobTemplateService: JobTemplateService) {
+
+  @GetMapping(path = Array("/jobTemplateId"))
+  def getJobTemplateIdByName(@RequestParam name: String): CompletableFuture[Long] = {
+    jobTemplateService.getJobTemplateId(name).toJava.toCompletableFuture
+  }
+
+}
+

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobTemplateController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobTemplateController.scala
@@ -29,7 +29,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class JobTemplateController @Inject()(jobTemplateService: JobTemplateService) {
 
   @GetMapping(path = Array("/jobTemplateId"))
-  def getJobTemplateIdByName(@RequestParam name: String): CompletableFuture[Long] = {
+  def getJobTemplateIdByName(@RequestParam name: String): CompletableFuture[Option[Long]] = {
     jobTemplateService.getJobTemplateId(name).toJava.toCompletableFuture
   }
 

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
@@ -27,7 +27,7 @@ trait JobTemplateService {
   val jobTemplateRepository: JobTemplateRepository
 
   def resolveJobTemplate(dagDefinition: DagDefinitionJoined)(implicit ec: ExecutionContext): Future[DagInstanceJoined]
-  def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Long]
+  def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Option[Long]]
 }
 
 @Service
@@ -39,7 +39,7 @@ class JobTemplateServiceImpl(override val jobTemplateRepository: JobTemplateRepo
     )
   }
 
-  override def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Long] =
+  override def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Option[Long]] =
     jobTemplateRepository.getJobTemplateIdByName(name)
 
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
@@ -27,6 +27,7 @@ trait JobTemplateService {
   val jobTemplateRepository: JobTemplateRepository
 
   def resolveJobTemplate(dagDefinition: DagDefinitionJoined)(implicit ec: ExecutionContext): Future[DagInstanceJoined]
+  def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Long]
 }
 
 @Service
@@ -37,4 +38,8 @@ class JobTemplateServiceImpl(override val jobTemplateRepository: JobTemplateRepo
       jobTemplates => JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, jobTemplates)
     )
   }
+
+  override def getJobTemplateId(name: String)(implicit ec: ExecutionContext): Future[Long] =
+    jobTemplateRepository.getJobTemplateIdByName(name)
+
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateService.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.services
+
+import org.springframework.stereotype.Service
+import za.co.absa.hyperdrive.trigger.api.rest.utils.JobTemplateResolutionUtil
+import za.co.absa.hyperdrive.trigger.models.{DagDefinition, DagDefinitionJoined, DagInstanceJoined, JobDefinition, JobForRun, JobInstance, JobParameters, JobTemplate}
+import za.co.absa.hyperdrive.trigger.persistance.{JobDefinitionRepository, JobTemplateRepository}
+
+import scala.collection.immutable.SortedMap
+import scala.concurrent.{ExecutionContext, Future}
+
+trait JobTemplateService {
+  val jobTemplateRepository: JobTemplateRepository
+
+  def resolveJobTemplate(dagDefinition: DagDefinitionJoined)(implicit ec: ExecutionContext): Future[DagInstanceJoined]
+}
+
+@Service
+class JobTemplateServiceImpl(override val jobTemplateRepository: JobTemplateRepository) extends JobTemplateService {
+  override def resolveJobTemplate(dagDefinitionJoined: DagDefinitionJoined)(implicit ec: ExecutionContext): Future[DagInstanceJoined] = {
+    val jobTemplateIds = dagDefinitionJoined.jobDefinitions.map(_.jobTemplateId)
+    jobTemplateRepository.getJobTemplatesByIds(jobTemplateIds).map(
+      jobTemplates => JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, jobTemplates)
+    )
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowService.scala
@@ -50,7 +50,6 @@ class WorkflowServiceImpl(override val workflowRepository: WorkflowRepository,
                           override val dagInstanceRepository: DagInstanceRepository,
                           override val jobTemplateService: JobTemplateService,
                           override val workflowValidationService: WorkflowValidationService) extends WorkflowService {
-  private val logger = LoggerFactory.getLogger(this.getClass)
 
   def createWorkflow(workflow: WorkflowJoined)(implicit ec: ExecutionContext): Future[Either[Seq[ApiError], WorkflowJoined]] = {
     val userName = getUserName.apply();

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowService.scala
@@ -15,6 +15,7 @@
 
 package za.co.absa.hyperdrive.trigger.api.rest.services
 
+import org.slf4j.LoggerFactory
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Service
@@ -27,6 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait WorkflowService {
   val workflowRepository: WorkflowRepository
   val dagInstanceRepository: DagInstanceRepository
+  val jobTemplateService: JobTemplateService
   val workflowValidationService: WorkflowValidationService
 
   def createWorkflow(workflow: WorkflowJoined)(implicit ec: ExecutionContext): Future[Either[Seq[ApiError], WorkflowJoined]]
@@ -46,7 +48,9 @@ trait WorkflowService {
 @Service
 class WorkflowServiceImpl(override val workflowRepository: WorkflowRepository,
                           override val dagInstanceRepository: DagInstanceRepository,
+                          override val jobTemplateService: JobTemplateService,
                           override val workflowValidationService: WorkflowValidationService) extends WorkflowService {
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   def createWorkflow(workflow: WorkflowJoined)(implicit ec: ExecutionContext): Future[Either[Seq[ApiError], WorkflowJoined]] = {
     val userName = getUserName.apply();
@@ -136,9 +140,13 @@ class WorkflowServiceImpl(override val workflowRepository: WorkflowRepository,
   }
 
   override def runWorkflow(workflowId: Long)(implicit ec: ExecutionContext): Future[Boolean] = {
-    workflowRepository.getWorkflow(workflowId).map( joinedWorkflow =>
-      dagInstanceRepository.insertJoinedDagInstance(joinedWorkflow.dagDefinitionJoined.toDagInstanceJoined())
-    ).map(_ => true)
+    for {
+      joinedWorkflow <- workflowRepository.getWorkflow(workflowId)
+      dagInstanceJoined <- jobTemplateService.resolveJobTemplate(joinedWorkflow.dagDefinitionJoined)
+      _ <- dagInstanceRepository.insertJoinedDagInstance(dagInstanceJoined)
+    } yield {
+      true
+    }
   }
 
   override def runWorkflowJobs(workflowId: Long, jobIds: Seq[Long])(implicit ec: ExecutionContext): Future[Boolean] = {
@@ -153,7 +161,12 @@ class WorkflowServiceImpl(override val workflowRepository: WorkflowRepository,
         val dagDefinitionWithFilteredJobs = dagDefinitionJoined.copy(
           jobDefinitions = dagDefinitionJoined.jobDefinitions.filter(job => jobIds.contains(job.id))
         )
-        dagInstanceRepository.insertJoinedDagInstance(dagDefinitionWithFilteredJobs.toDagInstanceJoined()).map(_=>true)
+        for {
+          dagInstanceJoined <- jobTemplateService.resolveJobTemplate(dagDefinitionWithFilteredJobs)
+          _ <- dagInstanceRepository.insertJoinedDagInstance(dagInstanceJoined)
+        } yield {
+          true
+        }
       }
     })
   }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowValidationService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowValidationService.scala
@@ -107,7 +107,7 @@ class WorkflowValidationServiceImpl @Inject()(override val workflowRepository: W
         updatedJobOption.map(updatedJob =>
           Seq(
             originalJob.name == updatedJob.name,
-            originalJob.jobType == updatedJob.jobType,
+            originalJob.jobTemplateId == updatedJob.jobTemplateId,
             originalJob.order == updatedJob.order,
             originalJob.jobParameters.variables.equals(updatedJob.jobParameters.variables),
             areMapsEqual(originalJob.jobParameters.maps, updatedJob.jobParameters.maps),

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtil.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtil.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.utils
+
+import java.time.LocalDateTime
+
+import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
+import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.InQueue
+import za.co.absa.hyperdrive.trigger.models._
+
+import scala.collection.immutable.SortedMap
+
+
+object JobTemplateResolutionUtil {
+
+  def resolveDagDefinitionJoined(dagDefinitionJoined: DagDefinitionJoined, jobTemplates: Seq[JobTemplate]): DagInstanceJoined = {
+    val jobTemplatesLookup = jobTemplates.map(t => t.id -> t).toMap
+    DagInstanceJoined(
+      status = DagInstanceStatuses.InQueue,
+      workflowId = dagDefinitionJoined.workflowId,
+      jobInstances = dagDefinitionJoined.jobDefinitions.map(jd => resolveJobDefinition(jd, jobTemplatesLookup(jd.jobTemplateId))),
+      started = LocalDateTime.now(),
+      finished = None
+    )
+  }
+
+  private def resolveJobDefinition(jobDefinition: JobDefinition, jobTemplate: JobTemplate): JobInstance = {
+    JobInstance(
+      jobName = jobDefinition.name,
+      jobType = jobTemplate.jobType,
+      jobParameters = mergeJobParameters(jobDefinition.jobParameters, jobTemplate.jobParameters),
+      jobStatus = InQueue,
+      executorJobId = None,
+      created = LocalDateTime.now(),
+      updated = None,
+      order = jobDefinition.order,
+      dagInstanceId = 0
+    )
+  }
+
+  private def mergeJobParameters(primary: JobParameters, secondary: JobParameters): JobParameters = {
+    JobParameters(
+      variables = mergeMapsOfStrings(primary.variables, secondary.variables),
+      maps = mergeMapsOfLists(primary.maps, secondary.maps),
+      keyValuePairs = mergeMapsOfSortedMaps(primary.keyValuePairs, secondary.keyValuePairs)
+    )
+  }
+
+  private def mergeMapsOfStrings(primary: Map[String, String], secondary: Map[String, String]) =
+    secondary ++ primary
+
+  private def mergeMapsOfLists(primary: Map[String, List[String]], secondary: Map[String, List[String]]) =
+    mergeMapsOfIterables(primary, secondary, (first: List[String], second: List[String]) => second ++ first)
+
+  private def mergeMapsOfSortedMaps(primary: Map[String, SortedMap[String, String]],
+    secondary: Map[String, SortedMap[String, String]]) =
+    mergeMapsOfIterables(primary, secondary,
+      (first: SortedMap[String, String], second: SortedMap[String, String]) => second ++ first)
+
+  private def mergeMapsOfIterables[T <: Iterable[_]](primary: Map[String, T], secondary: Map[String, T], mergeFn: (T, T) => T) = {
+    val sharedKeys = primary.keySet.intersect(secondary.keySet)
+    primary.filterKeys(key => !sharedKeys.contains(key)) ++
+    secondary.filterKeys(key => !sharedKeys.contains(key)) ++
+    primary.filterKeys(key => sharedKeys.contains(key))
+        .map{ case (key, iterable) => key -> mergeFn.apply(iterable, secondary(key)) }
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/DagDefinition.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/DagDefinition.scala
@@ -15,10 +15,6 @@
 
 package za.co.absa.hyperdrive.trigger.models
 
-import java.time.LocalDateTime
-
-import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
-
 case class DagDefinition(
   workflowId: Long,
   id: Long = 0
@@ -29,16 +25,6 @@ case class DagDefinitionJoined(
   jobDefinitions: Seq[JobDefinition],
   id: Long = 0
 ){
-  def toDagInstanceJoined(): DagInstanceJoined = {
-    DagInstanceJoined(
-      status = DagInstanceStatuses.InQueue,
-      workflowId = this.workflowId,
-      jobInstances = jobDefinitions.map(_.toJobInstance()),
-      started = LocalDateTime.now(),
-      finished = None
-    )
-  }
-
   def toDag(): DagDefinition = {
     DagDefinition(
       workflowId = this.workflowId,

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobDefinition.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobDefinition.scala
@@ -22,6 +22,7 @@ import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
 
 case class JobDefinition(
   dagDefinitionId: Long = 0,
+  jobTemplateId: Long = 0,
   name: String,
   jobType: JobType,
   jobParameters: JobParameters,
@@ -42,3 +43,4 @@ case class JobDefinition(
     )
   }
 }
+

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobDefinition.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobDefinition.scala
@@ -15,13 +15,10 @@
 
 package za.co.absa.hyperdrive.trigger.models
 
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
-
 case class JobDefinition(
   dagDefinitionId: Long = 0,
   jobTemplateId: Long = 0,
   name: String,
-  jobType: JobType,
   jobParameters: JobParameters,
   order: Int,
   id: Long = 0

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobTemplate.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobTemplate.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.models
+
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
+
+case class JobTemplate(
+  name: String,
+  jobType: JobType,
+  jobParameters: JobParameters,
+  id: Long = 0
+)

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobDefinitionTable.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobDefinitionTable.scala
@@ -30,7 +30,6 @@ trait JobDefinitionTable {
     def dagDefinitionId: Rep[Long] = column[Long]("dag_definition_id")
     def jobTemplateId: Rep[Long] = column[Long]("job_template_id")
     def name: Rep[String] = column[String]("name")
-    def jobType: Rep[JobType] = column[JobType]("job_type")
     def variables: Rep[Map[String, String]] = column[Map[String, String]]("variables")
     def maps: Rep[Map[String, List[String]]] = column[Map[String, List[String]]]("maps")
     def keyValuePairs: Rep[Map[String, SortedMap[String, String]]] = column[Map[String, SortedMap[String, String]]]("key_value_pairs")
@@ -43,28 +42,26 @@ trait JobDefinitionTable {
     def jobTemplate_fk: ForeignKeyQuery[JobTemplateTable, JobTemplate] =
       foreignKey("job_definition_job_template_fk", jobTemplateId, TableQuery[JobTemplateTable])(_.id)
 
-    def * : ProvenShape[JobDefinition] = (dagDefinitionId, jobTemplateId, name, jobType, variables, maps, keyValuePairs,
+    def * : ProvenShape[JobDefinition] = (dagDefinitionId, jobTemplateId, name, variables, maps, keyValuePairs,
       order, id) <> (
       jobDefinitionTuple =>
         JobDefinition.apply(
           dagDefinitionId = jobDefinitionTuple._1,
           jobTemplateId = jobDefinitionTuple._2,
           name = jobDefinitionTuple._3,
-          jobType = jobDefinitionTuple._4,
           jobParameters = JobParameters(
-            variables = jobDefinitionTuple._5,
-            maps = jobDefinitionTuple._6,
-            keyValuePairs = jobDefinitionTuple._7
+            variables = jobDefinitionTuple._4,
+            maps = jobDefinitionTuple._5,
+            keyValuePairs = jobDefinitionTuple._6
           ),
-          order = jobDefinitionTuple._8,
-          id = jobDefinitionTuple._9
+          order = jobDefinitionTuple._7,
+          id = jobDefinitionTuple._8
         ),
       (jobDefinition: JobDefinition) =>
         Option(
           jobDefinition.dagDefinitionId,
           jobDefinition.jobTemplateId,
           jobDefinition.name,
-          jobDefinition.jobType,
           jobDefinition.jobParameters.variables,
           jobDefinition.jobParameters.maps,
           jobDefinition.jobParameters.keyValuePairs,

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobTemplateTable.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobTemplateTable.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.models.tables
+
+import slick.lifted.{ForeignKeyQuery, ProvenShape}
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
+import za.co.absa.hyperdrive.trigger.models.{DagDefinition, JobDefinition, JobParameters, JobTemplate}
+
+import scala.collection.immutable.SortedMap
+
+trait JobTemplateTable {
+  this: Profile with JdbcTypeMapper =>
+  import profile.api._
+
+  final class JobTemplateTable(tag: Tag) extends Table[JobTemplate](tag, _tableName = "job_template") {
+
+    def name: Rep[String] = column[String]("name")
+    def jobType: Rep[JobType] = column[JobType]("job_type")
+    def variables: Rep[Map[String, String]] = column[Map[String, String]]("variables")
+    def maps: Rep[Map[String, List[String]]] = column[Map[String, List[String]]]("maps")
+    def keyValuePairs: Rep[Map[String, SortedMap[String, String]]] = column[Map[String, SortedMap[String, String]]]("key_value_pairs")
+    def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc, O.SqlType("BIGSERIAL"))
+
+    def * : ProvenShape[JobTemplate] = (name, jobType, variables, maps, keyValuePairs, id) <> (
+      jobTemplateTuple =>
+        JobTemplate.apply(
+          name = jobTemplateTuple._1,
+          jobType = jobTemplateTuple._2,
+          jobParameters = JobParameters(
+            variables = jobTemplateTuple._3,
+            maps = jobTemplateTuple._4,
+            keyValuePairs = jobTemplateTuple._5
+          ),
+          id = jobTemplateTuple._6
+        ),
+      (jobTemplate: JobTemplate) =>
+        Option(
+          jobTemplate.name,
+          jobTemplate.jobType,
+          jobTemplate.jobParameters.variables,
+          jobTemplate.jobParameters.maps,
+          jobTemplate.jobParameters.keyValuePairs,
+          jobTemplate.id
+        )
+    )
+  }
+
+  lazy val jobTemplateTable = TableQuery[JobTemplateTable]
+
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobTemplateTable.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobTemplateTable.scala
@@ -27,7 +27,7 @@ trait JobTemplateTable {
 
   final class JobTemplateTable(tag: Tag) extends Table[JobTemplate](tag, _tableName = "job_template") {
 
-    def name: Rep[String] = column[String]("name")
+    def name: Rep[String] = column[String]("name", O.Unique)
     def jobType: Rep[JobType] = column[JobType]("job_type")
     def variables: Rep[Map[String, String]] = column[Map[String, String]]("variables")
     def maps: Rep[Map[String, List[String]]] = column[Map[String, List[String]]]("maps")

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
@@ -25,7 +25,7 @@ import scala.util.{Failure, Success}
 
 trait JobTemplateRepository extends Repository {
   def insertJobTemplate(jobTemplate: JobTemplate)(implicit ec: ExecutionContext): Future[Either[ApiError, Long]]
-  def getJobTemplate(id: Long)(implicit ec: ExecutionContext): Future[JobTemplate]
+  def getJobTemplatesByIds(ids: Seq[Long])(implicit ec: ExecutionContext): Future[Seq[JobTemplate]]
   def getJobTemplates()(implicit ec: ExecutionContext): Future[Seq[JobTemplate]]
 }
 
@@ -34,10 +34,8 @@ class JobTemplateRepositoryImpl extends JobTemplateRepository {
   import profile.api._
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  override def getJobTemplate(id: Long)(implicit ec: ExecutionContext): Future[JobTemplate] = db.run(
-    jobTemplateTable.filter(_.id === id).result.map(
-      jobTemplate => jobTemplate.headOption.getOrElse(throw new Exception(s"JobTemplate with ${id} does not exist."))
-    )
+  override def getJobTemplatesByIds(ids: Seq[Long])(implicit ec: ExecutionContext): Future[Seq[JobTemplate]] = db.run(
+    jobTemplateTable.filter(_.id inSetBind ids).result
   )
 
   override def getJobTemplates()(implicit ec: ExecutionContext): Future[Seq[JobTemplate]] = db.run(

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
 trait JobTemplateRepository extends Repository {
   def insertJobTemplate(jobTemplate: JobTemplate)(implicit ec: ExecutionContext): Future[Either[ApiError, Long]]
   def getJobTemplatesByIds(ids: Seq[Long])(implicit ec: ExecutionContext): Future[Seq[JobTemplate]]
-  def getJobTemplateIdByName(name: String)(implicit ec: ExecutionContext): Future[Long]
+  def getJobTemplateIdByName(name: String)(implicit ec: ExecutionContext): Future[Option[Long]]
 }
 
 @stereotype.Repository
@@ -53,15 +53,14 @@ class JobTemplateRepositoryImpl extends JobTemplateRepository {
     )
   }
 
-  override def getJobTemplateIdByName(name: String)(implicit ec: ExecutionContext): Future[Long] =
+  override def getJobTemplateIdByName(name: String)(implicit ec: ExecutionContext): Future[Option[Long]] =
     db.run(jobTemplateTable
       .filter(_.name === name)
       .map(_.id)
       .take(1)
       .result
       .asTry.map {
-        case Success(value) if value.nonEmpty => value.head
-        case Success(value) => throw new Exception(s"No jobTemplate found for name $name")
+        case Success(value) => value.headOption
         case Failure(ex) =>
           logger.error(s"Unexpected error occurred for getJobTemplateIdByName. name:$name", ex)
           throw ex

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepository.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.persistance
+
+import org.springframework.stereotype
+import za.co.absa.hyperdrive.trigger.models.{JobForRun, JobTemplate}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait JobTemplateRepository extends Repository {
+  def getJobTemplate(id: Long)(implicit ec: ExecutionContext): Future[JobTemplate]
+  def getJobTemplates()(implicit ec: ExecutionContext): Future[Seq[JobTemplate]]
+}
+
+@stereotype.Repository
+class JobTemplateRepositoryImpl extends JobTemplateRepository {
+  import profile.api._
+
+  override def getJobTemplate(id: Long)(implicit ec: ExecutionContext): Future[JobTemplate] = db.run(
+    jobTemplateTable.filter(_.id === id).result.map(
+      jobTemplate => jobTemplate.headOption.getOrElse(throw new Exception(s"JobTemplate with ${id} does not exist."))
+    )
+  )
+
+  override def getJobTemplates()(implicit ec: ExecutionContext): Future[Seq[JobTemplate]] = db.run(
+    jobTemplateTable.sortBy(_.name).result
+  )
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/Repository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/Repository.scala
@@ -27,7 +27,9 @@ trait Repository
     with SensorTable
     with WorkflowTable
     with DagRunTable
-    with WorkflowHistoryTable with Profile with JdbcTypeMapper {
+    with WorkflowHistoryTable
+    with JobTemplateTable
+    with Profile with JdbcTypeMapper {
 
   val profile: JdbcProfile = PostgresDB.profile
   lazy val db = PostgresDB.db

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateFixture.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateFixture.scala
@@ -1,0 +1,41 @@
+
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.services
+
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes
+import za.co.absa.hyperdrive.trigger.models.{JobParameters, JobTemplate}
+
+object JobTemplateFixture {
+
+  val GenericSparkJobTemplate: JobTemplate = {
+    JobTemplate(
+      name = "Generic Spark Job Template",
+      jobType = JobTypes.Spark,
+      jobParameters = JobParameters(Map(), Map(), Map()),
+      id = 1
+    )
+  }
+
+  val GenericShellJobTemplate: JobTemplate = {
+    JobTemplate(
+      name = "Generic Shell Job Template",
+      jobType = JobTypes.Shell,
+      jobParameters = JobParameters(Map(), Map(), Map()),
+      id = 2
+    )
+  }
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.hyperdrive.trigger.api.rest.services
 
-import org.mockito.ArgumentMatchers._
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
@@ -35,7 +35,7 @@ class JobTemplateServiceTest extends AsyncFlatSpec with Matchers with MockitoSug
     reset(jobTemplateRepository)
   }
 
-  "JobTemplateService.resolveJobTemplate" should "resolve the job template" in {
+  "resolveJobTemplate" should "resolve the job template" in {
     // given
     val dagDefinitionJoined = WorkflowFixture.createWorkflowJoined().dagDefinitionJoined
     val jobTemplates = Seq(GenericShellJobTemplate, GenericSparkJobTemplate)
@@ -50,5 +50,16 @@ class JobTemplateServiceTest extends AsyncFlatSpec with Matchers with MockitoSug
     jobInstances should have size 2
     jobInstances.head.jobType shouldBe JobTypes.Spark
     jobInstances(1).jobType shouldBe JobTypes.Shell
+  }
+
+  "getJobTemplateId" should "get the job template id" in {
+    // given
+    when(jobTemplateRepository.getJobTemplateIdByName(eqTo("some-template"))(any[ExecutionContext])).thenReturn(Future{42L})
+
+    // when
+    val result = await(underTest.getJobTemplateId("some-template"))
+
+    // then
+    result shouldBe 42L
   }
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
@@ -54,12 +54,12 @@ class JobTemplateServiceTest extends AsyncFlatSpec with Matchers with MockitoSug
 
   "getJobTemplateId" should "get the job template id" in {
     // given
-    when(jobTemplateRepository.getJobTemplateIdByName(eqTo("some-template"))(any[ExecutionContext])).thenReturn(Future{42L})
+    when(jobTemplateRepository.getJobTemplateIdByName(eqTo("some-template"))(any[ExecutionContext])).thenReturn(Future{Some(42L)})
 
     // when
     val result = await(underTest.getJobTemplateId("some-template"))
 
     // then
-    result shouldBe 42L
+    result.get shouldBe 42L
   }
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.services
+
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
+import za.co.absa.hyperdrive.trigger.TestUtils.await
+import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateFixture.{GenericShellJobTemplate, GenericSparkJobTemplate}
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes
+import za.co.absa.hyperdrive.trigger.persistance.JobTemplateRepository
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class JobTemplateServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  private val jobTemplateRepository = mock[JobTemplateRepository]
+  private val underTest = new JobTemplateServiceImpl(jobTemplateRepository)
+
+  before {
+    reset(jobTemplateRepository)
+  }
+
+  "JobTemplateService.resolveJobTemplate" should "resolve the job template" in {
+    // given
+    val dagDefinitionJoined = WorkflowFixture.createWorkflowJoined().dagDefinitionJoined
+    val jobTemplates = Seq(GenericShellJobTemplate, GenericSparkJobTemplate)
+
+    when(jobTemplateRepository.getJobTemplatesByIds(any())(any[ExecutionContext])).thenReturn(Future{jobTemplates})
+
+    // when
+    val dagInstanceJoined = await(underTest.resolveJobTemplate(dagDefinitionJoined))
+
+    // then
+    val jobInstances = dagInstanceJoined.jobInstances
+    jobInstances should have size 2
+    jobInstances.head.jobType shouldBe JobTypes.Spark
+    jobInstances(1).jobType shouldBe JobTypes.Shell
+  }
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowFixture.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowFixture.scala
@@ -20,6 +20,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 import org.apache.commons.lang3.RandomStringUtils
+import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateFixture.{GenericShellJobTemplate, GenericSparkJobTemplate}
 import za.co.absa.hyperdrive.trigger.models.{DagDefinitionJoined, JobDefinition, JobParameters, Properties, Sensor, Settings, WorkflowJoined}
 import za.co.absa.hyperdrive.trigger.models.enums.{JobTypes, SensorTypes}
 import za.co.absa.hyperdrive.trigger.scheduler.sensors.kafka.KafkaSettings
@@ -64,6 +65,7 @@ object WorkflowFixture {
         jobDefinitions = Seq(
           JobDefinition(
             dagDefinitionId = 0,
+            jobTemplateId = GenericSparkJobTemplate.id,
             name = "TestJob1",
             jobType = JobTypes.Spark,
             jobParameters = JobParameters(
@@ -78,6 +80,7 @@ object WorkflowFixture {
           ),
           JobDefinition(
             dagDefinitionId = 0,
+            jobTemplateId = GenericShellJobTemplate.id,
             name = "TestJob2",
             jobType = JobTypes.Shell,
             jobParameters = JobParameters(
@@ -121,6 +124,7 @@ object WorkflowFixture {
         jobDefinitions = Seq(
           JobDefinition(
             dagDefinitionId = 0,
+            jobTemplateId = GenericSparkJobTemplate.id,
             name = s"${randomString()} Driver",
             jobType = JobTypes.Spark,
             jobParameters = JobParameters(
@@ -164,6 +168,7 @@ object WorkflowFixture {
           ),
           JobDefinition(
             dagDefinitionId = 0,
+            jobTemplateId = GenericSparkJobTemplate.id,
             name = s"${randomString()} Publisher",
             jobType = JobTypes.Spark,
             jobParameters = JobParameters(
@@ -209,6 +214,7 @@ object WorkflowFixture {
         jobDefinitions = Seq(
           JobDefinition(
             dagDefinitionId = 0,
+            jobTemplateId = GenericShellJobTemplate.id,
             name = s"${randomString()}",
             jobType = JobTypes.Shell,
             jobParameters = JobParameters(

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowFixture.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowFixture.scala
@@ -67,7 +67,6 @@ object WorkflowFixture {
             dagDefinitionId = 0,
             jobTemplateId = GenericSparkJobTemplate.id,
             name = "TestJob1",
-            jobType = JobTypes.Spark,
             jobParameters = JobParameters(
               variables = Map("jobJar" -> "/dir/driver.jar",
                 "mainClass" -> "aaa.bbb.TestClass",
@@ -82,7 +81,6 @@ object WorkflowFixture {
             dagDefinitionId = 0,
             jobTemplateId = GenericShellJobTemplate.id,
             name = "TestJob2",
-            jobType = JobTypes.Shell,
             jobParameters = JobParameters(
               variables = Map("jobJar" -> "/dir/driver.jar",
                 "mainClass" -> "aaa.bbb.TestClass"
@@ -126,7 +124,6 @@ object WorkflowFixture {
             dagDefinitionId = 0,
             jobTemplateId = GenericSparkJobTemplate.id,
             name = s"${randomString()} Driver",
-            jobType = JobTypes.Spark,
             jobParameters = JobParameters(
               variables = Map(
                 "jobJar" -> s"${randomString()}/driver.jar",
@@ -170,7 +167,6 @@ object WorkflowFixture {
             dagDefinitionId = 0,
             jobTemplateId = GenericSparkJobTemplate.id,
             name = s"${randomString()} Publisher",
-            jobType = JobTypes.Spark,
             jobParameters = JobParameters(
               variables = Map(
                 "jobJar" -> s"${randomString()}/publisher.jar",
@@ -216,7 +212,6 @@ object WorkflowFixture {
             dagDefinitionId = 0,
             jobTemplateId = GenericShellJobTemplate.id,
             name = s"${randomString()}",
-            jobType = JobTypes.Shell,
             jobParameters = JobParameters(
               variables = Map(
                 "scriptLocation" -> s"${randomString()}/script.sh"

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowServiceTest.scala
@@ -21,9 +21,10 @@ import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
-import za.co.absa.hyperdrive.trigger.TestUtils
+import za.co.absa.hyperdrive.trigger.TestUtils.await
+import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
 import za.co.absa.hyperdrive.trigger.models.errors.{ApiError, DatabaseError, ValidationError}
-import za.co.absa.hyperdrive.trigger.models.{DagInstanceJoined, Project, Workflow, WorkflowJoined}
+import za.co.absa.hyperdrive.trigger.models.{DagDefinitionJoined, DagInstanceJoined, Project, Workflow, WorkflowJoined}
 import za.co.absa.hyperdrive.trigger.persistance.{DagInstanceRepository, WorkflowRepository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,15 +33,17 @@ import scala.concurrent.{ExecutionContext, Future}
 class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
   private val workflowRepository = mock[WorkflowRepository]
   private val dagInstanceRepository = mock[DagInstanceRepository]
+  private val jobTemplateService = mock[JobTemplateService]
   private val workflowValidationService = mock[WorkflowValidationService]
   private val userName = "fakeUserName"
-  private val underTest = new WorkflowServiceImpl(workflowRepository, dagInstanceRepository, workflowValidationService){
+  private val underTest = new WorkflowServiceImpl(workflowRepository, dagInstanceRepository, jobTemplateService, workflowValidationService){
     override private[services] def getUserName: () => String = () => userName
   }
 
   before {
     reset(workflowRepository)
     reset(dagInstanceRepository)
+    reset(jobTemplateService)
     reset(workflowValidationService)
   }
 
@@ -52,7 +55,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(workflowRepository.getWorkflow(eqTo(workflowJoined.id))(any[ExecutionContext])).thenReturn(Future{workflowJoined})
 
     // when
-    val result = TestUtils.await(underTest.createWorkflow(workflowJoined))
+    val result = await(underTest.createWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository).insertWorkflow(eqTo(workflowJoined), eqTo(userName))(any[ExecutionContext])
@@ -67,7 +70,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
       .thenReturn(Future{errors})
 
     // when
-    val result = TestUtils.await(underTest.createWorkflow(workflowJoined))
+    val result = await(underTest.createWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository, never()).insertWorkflow(any[WorkflowJoined], any[String])(any[ExecutionContext])
@@ -84,7 +87,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
       .thenReturn(Future{Left(error)})
 
     // when
-    val result = TestUtils.await(underTest.createWorkflow(workflowJoined))
+    val result = await(underTest.createWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository).insertWorkflow(eqTo(workflowJoined), eqTo(userName))(any[ExecutionContext])
@@ -101,7 +104,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(workflowRepository.getWorkflow(eqTo(workflowJoined.id))(any[ExecutionContext])).thenReturn(Future{workflowJoined})
 
     // when
-    val result = TestUtils.await(underTest.updateWorkflow(workflowJoined))
+    val result = await(underTest.updateWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository).updateWorkflow(any[WorkflowJoined], any[String])(any[ExecutionContext])
@@ -117,7 +120,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(workflowRepository.getWorkflow(eqTo(workflowJoined.id))(any[ExecutionContext])).thenReturn(Future{workflowJoined})
 
     // when
-    val result = TestUtils.await(underTest.updateWorkflow(workflowJoined))
+    val result = await(underTest.updateWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository, never()).updateWorkflow(any[WorkflowJoined], any[String])(any[ExecutionContext])
@@ -134,7 +137,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
       .thenReturn(Future{Left(error)})
 
     // when
-    val result = TestUtils.await(underTest.updateWorkflow(workflowJoined))
+    val result = await(underTest.updateWorkflow(workflowJoined))
 
     // then
     verify(workflowRepository).updateWorkflow(any[WorkflowJoined], any[String])(any[ExecutionContext])
@@ -146,7 +149,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(workflowRepository.getWorkflows()(any[ExecutionContext])).thenReturn(Future{Seq()})
 
     // when
-    val result: Seq[Project] = TestUtils.await(underTest.getProjects())
+    val result: Seq[Project] = await(underTest.getProjects())
 
     // then
     verify(workflowRepository, times(1)).getWorkflows()
@@ -176,7 +179,7 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(workflowRepository.getWorkflows()(any[ExecutionContext])).thenReturn(Future{worfklows})
 
     // when
-    val result: Seq[Project] = TestUtils.await(underTest.getProjects())
+    val result: Seq[Project] = await(underTest.getProjects())
 
     // then
     verify(workflowRepository, times(1)).getWorkflows()
@@ -185,28 +188,27 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
 
   "WorkflowService.runWorkflowJobs" should "should insert joined dag instance when jobs ids exist in workflow" in {
     // given
-    val underTest = new WorkflowServiceImpl(workflowRepository, dagInstanceRepository, workflowValidationService)
-
     val workflowJoined = WorkflowFixture.createWorkflowJoined().copy()
     val workflowId = workflowJoined.id
     val jobIds = workflowJoined.dagDefinitionJoined.jobDefinitions.map(_.id)
 
+    val dagInstanceJoined = createDagInstanceJoined()
     when(workflowRepository.getWorkflow(eqTo(workflowId))(any[ExecutionContext])).thenReturn(Future{workflowJoined})
-    when(dagInstanceRepository.insertJoinedDagInstance(any[DagInstanceJoined])(any[ExecutionContext])).thenReturn(Future{(): Unit})
+    when(jobTemplateService.resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])).thenReturn(Future{dagInstanceJoined})
+    when(dagInstanceRepository.insertJoinedDagInstance(eqTo(dagInstanceJoined))(any[ExecutionContext])).thenReturn(Future{(): Unit})
 
     // when
-    val result: Boolean = TestUtils.await(underTest.runWorkflowJobs(workflowId, jobIds))
+    val result: Boolean = await(underTest.runWorkflowJobs(workflowId, jobIds))
 
     // then
     verify(workflowRepository, times(1)).getWorkflow(any[Long])(any[ExecutionContext])
+    verify(jobTemplateService, times(1)).resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])
     verify(dagInstanceRepository, times(1)).insertJoinedDagInstance(any[DagInstanceJoined])(any[ExecutionContext])
     result shouldBe true
   }
 
   "WorkflowService.runWorkflowJobs" should "should not insert joined dag instance when jobs ids does not exist in workflow" in {
     // given
-    val underTest = new WorkflowServiceImpl(workflowRepository, dagInstanceRepository, workflowValidationService)
-
     val workflowJoined = WorkflowFixture.createWorkflowJoined().copy()
     val workflowId = workflowJoined.id
     val jobIds: Seq[Long] = Seq(9999, 8888)
@@ -215,13 +217,24 @@ class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar 
     when(dagInstanceRepository.insertJoinedDagInstance(any[DagInstanceJoined])(any[ExecutionContext])).thenReturn(Future{(): Unit})
 
     // when
-    val result: Boolean = TestUtils.await(underTest.runWorkflowJobs(workflowId, jobIds))
+    val result: Boolean = await(underTest.runWorkflowJobs(workflowId, jobIds))
 
     // then
     verify(workflowRepository, times(1)).getWorkflow(any[Long])(any[ExecutionContext])
+    verify(jobTemplateService, never).resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])
     verify(dagInstanceRepository, never).insertJoinedDagInstance(any[DagInstanceJoined])(any[ExecutionContext])
     result shouldBe false
   }
 
+  private def createDagInstanceJoined() = {
+    DagInstanceJoined(
+      status = DagInstanceStatuses.InQueue,
+      workflowId = 2,
+      jobInstances = Seq(),
+      started = LocalDateTime.now(),
+      finished = None,
+      id = 3
+    )
+  }
 
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtilTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtilTest.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.utils
+
+import org.scalatest.{FlatSpec, Matchers}
+import za.co.absa.hyperdrive.trigger.models.enums.{DagInstanceStatuses, JobStatuses, JobTypes}
+import za.co.absa.hyperdrive.trigger.models.{DagDefinitionJoined, JobDefinition, JobParameters}
+import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateFixture.{GenericShellJobTemplate, GenericSparkJobTemplate}
+
+import scala.collection.immutable.SortedMap
+
+class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
+
+  "resolveDagDefinition" should "return a DagInstance with the same jobType as in the template" in {
+    // given
+    val jobDefinition = createJobDefinition()
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
+    val jobTemplate = GenericSparkJobTemplate
+
+    // when
+    val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
+    
+    // then
+    dagInstanceJoined.status shouldBe DagInstanceStatuses.InQueue
+    val jobInstance = dagInstanceJoined.jobInstances.head
+    jobInstance.dagInstanceId shouldBe 0
+    jobInstance.jobStatus shouldBe JobStatuses.InQueue
+    jobInstance.jobName shouldBe "JobDefinition0"
+    jobInstance.jobType shouldBe JobTypes.Spark
+    jobInstance.order shouldBe 2
+    jobInstance.id shouldBe 0
+  }
+
+  it should "resolve templates for multiple JobDefinitions" in {
+    // given
+    val jobParameters1 = JobParameters(Map("key1" -> "value1"), Map(), Map())
+    val jobTemplate1 = GenericSparkJobTemplate.copy(id = 1)
+    val jobDefinition1 = createJobDefinition().copy(jobTemplateId = jobTemplate1.id, jobParameters = jobParameters1)
+
+    val jobParameters2 = JobParameters(Map("key2" -> "value2"), Map(), Map())
+    val jobTemplate2 = GenericShellJobTemplate.copy(id = 2)
+    val jobDefinition2 = createJobDefinition().copy(jobTemplateId = jobTemplate2.id, jobParameters = jobParameters2)
+
+    val dagDefinitionJoined = DagDefinitionJoined(jobDefinitions = Seq(jobDefinition1, jobDefinition2))
+
+    // when
+    val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate1, jobTemplate2))
+
+    // then
+    val jobInstances = dagInstanceJoined.jobInstances
+    jobInstances should have size 2
+    jobInstances.head.jobType shouldBe JobTypes.Spark
+    jobInstances.head.jobParameters.variables should contain theSameElementsAs Map("key1" -> "value1")
+    jobInstances(1).jobType shouldBe JobTypes.Shell
+    jobInstances(1).jobParameters.variables should contain theSameElementsAs Map("key2" -> "value2")
+  }
+  
+  it should "merge variables, overwriting template-specified by user-specified in case of key-conflicts" in {
+    // given
+    val userParameters = JobParameters(Map(
+      "userKey1" -> "userValue1",
+      "userKey2" -> "userValue2",
+      "sharedKey3" -> "userValueForSharedKey3",
+      "sharedKey4" -> "userValueForSharedKey4"
+    ), Map(), Map())
+    val templateParameters = JobParameters(Map(
+      "templateKey1" -> "templateValue1",
+      "templateKey2" -> "templateValue2",
+      "sharedKey3" -> "templateValueForSharedKey3",
+      "sharedKey4" -> "templateValueForSharedKey4"
+    ), Map(), Map())
+    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
+    val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+
+    // when
+    val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
+
+    // then
+    val jobInstance = dagInstanceJoined.jobInstances.head
+    jobInstance.jobParameters.variables should contain theSameElementsAs Map(
+      "userKey1" -> "userValue1",
+      "userKey2" -> "userValue2",
+      "templateKey1" -> "templateValue1",
+      "templateKey2" -> "templateValue2",
+      "sharedKey3" -> "userValueForSharedKey3",
+      "sharedKey4" -> "userValueForSharedKey4"
+    )
+  }
+
+  it should "merge maps, merging user-specified and template-specified lists in case of key-conflicts" in {
+    // given
+    val userParameters = JobParameters(Map(), Map(
+      "userKey1" -> List("value1ForUserKey1", "value2ForUserKey1"),
+      "userKey2" -> List("value1ForUserKey2", "value2ForUserKey2"),
+      "sharedKey3" -> List("userValue1ForSharedKey3", "userValue2ForSharedKey3"),
+      "sharedKey4" -> List("userValue1ForSharedKey4", "userValue2ForSharedKey4")
+    ), Map())
+    val templateParameters = JobParameters(Map(), Map(
+      "templateKey1" -> List("value1ForTemplateKey1", "value2ForTemplateKey1"),
+      "templateKey2" -> List("value1ForTemplateKey2", "value2ForTemplateKey2"),
+      "sharedKey3" -> List("templateValue1ForSharedKey3", "templateValue2ForSharedKey3"),
+      "sharedKey4" -> List("templateValue1ForSharedKey4", "templateValue2ForSharedKey4")
+    ), Map())
+    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
+    val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+
+    // when
+    val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
+
+    // then
+    val jobInstance = dagInstanceJoined.jobInstances.head
+    jobInstance.jobParameters.maps should contain theSameElementsAs Map(
+      "userKey1" -> List("value1ForUserKey1", "value2ForUserKey1"),
+      "userKey2" -> List("value1ForUserKey2", "value2ForUserKey2"),
+      "templateKey1" -> List("value1ForTemplateKey1", "value2ForTemplateKey1"),
+      "templateKey2" -> List("value1ForTemplateKey2", "value2ForTemplateKey2"),
+      "sharedKey3" -> List("templateValue1ForSharedKey3", "templateValue2ForSharedKey3", "userValue1ForSharedKey3", "userValue2ForSharedKey3"),
+      "sharedKey4" -> List("templateValue1ForSharedKey4", "templateValue2ForSharedKey4", "userValue1ForSharedKey4", "userValue2ForSharedKey4")
+    )
+  }
+
+  it should "merge key-value-pairs, overwriting template-specified by user-specified maps in case of key-conflicts" in {
+    // given
+    val userParameters = JobParameters(Map(), Map(), Map(
+      "userKey1" -> SortedMap("userKey11" -> "valueForUserKey11", "userKey12" -> "valueForUserKey12"),
+      "userKey2" -> SortedMap("userKey21" -> "valueForUserKey21", "userKey22" -> "valueForUserKey22"),
+      "sharedKey3" -> SortedMap("sharedKey31" -> "userValueForSharedKey31", "userKey32" -> "valueForUserKey32"),
+      "sharedKey4" -> SortedMap("sharedKey41" -> "userValueForSharedKey41", "userKey42" -> "valueForUserKey42")
+    ))
+    val templateParameters = JobParameters(Map(), Map(), Map(
+      "templateKey1" -> SortedMap("templateKey11" -> "valueForUserKey11", "userKey12" -> "valueForUserKey12"),
+      "templateKey2" -> SortedMap("templateKey21" -> "valueForUserKey21", "userKey22" -> "valueForUserKey22"),
+      "sharedKey3" -> SortedMap("sharedKey31" -> "templateValueForSharedKey31", "templateKey32" -> "valueForTemplateKey32"),
+      "sharedKey4" -> SortedMap("sharedKey41" -> "templateValueForSharedKey41", "templateKey42" -> "valueForTemplateKey42")
+    ))
+    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
+    val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+
+    // when
+    val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
+
+    // then
+    val jobInstance = dagInstanceJoined.jobInstances.head
+    jobInstance.jobParameters.keyValuePairs should contain theSameElementsAs Map(
+      "userKey1" -> SortedMap("userKey11" -> "valueForUserKey11", "userKey12" -> "valueForUserKey12"),
+      "userKey2" -> SortedMap("userKey21" -> "valueForUserKey21", "userKey22" -> "valueForUserKey22"),
+      "templateKey1" -> SortedMap("templateKey11" -> "valueForUserKey11", "userKey12" -> "valueForUserKey12"),
+      "templateKey2" -> SortedMap("templateKey21" -> "valueForUserKey21", "userKey22" -> "valueForUserKey22"),
+      "sharedKey3" -> Map(
+        "sharedKey31" -> "userValueForSharedKey31",
+        "userKey32" -> "valueForUserKey32",
+        "templateKey32" -> "valueForTemplateKey32"
+      ),
+      "sharedKey4" -> Map(
+        "sharedKey41" -> "userValueForSharedKey41",
+        "userKey42" -> "valueForUserKey42",
+        "templateKey42" -> "valueForTemplateKey42"
+      )
+    )
+  }
+  
+  private def createDagDefinitionJoined(jobDefinition: JobDefinition) = {
+    DagDefinitionJoined(jobDefinitions = Seq(jobDefinition))
+  }
+  
+  private def createJobDefinition() = {
+    JobDefinition(
+      dagDefinitionId = 53,
+      name = "JobDefinition0",
+      jobType = JobTypes.Spark,
+      jobParameters = JobParameters(Map(), Map(), Map()),
+      order = 2,
+      id = 42
+    )
+  }
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtilTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionUtilTest.scala
@@ -26,9 +26,9 @@ class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
 
   "resolveDagDefinition" should "return a DagInstance with the same jobType as in the template" in {
     // given
-    val jobDefinition = createJobDefinition()
-    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
     val jobTemplate = GenericSparkJobTemplate
+    val jobDefinition = createJobDefinition().copy(jobTemplateId = jobTemplate.id)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
 
     // when
     val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
@@ -82,9 +82,9 @@ class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
       "sharedKey3" -> "templateValueForSharedKey3",
       "sharedKey4" -> "templateValueForSharedKey4"
     ), Map(), Map())
-    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
-    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
     val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+    val jobDefinition = createJobDefinition().copy(jobTemplateId = jobTemplate.id, jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
 
     // when
     val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
@@ -115,9 +115,9 @@ class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
       "sharedKey3" -> List("templateValue1ForSharedKey3", "templateValue2ForSharedKey3"),
       "sharedKey4" -> List("templateValue1ForSharedKey4", "templateValue2ForSharedKey4")
     ), Map())
-    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
-    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
     val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+    val jobDefinition = createJobDefinition().copy(jobTemplateId = jobTemplate.id, jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
 
     // when
     val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
@@ -148,9 +148,9 @@ class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
       "sharedKey3" -> SortedMap("sharedKey31" -> "templateValueForSharedKey31", "templateKey32" -> "valueForTemplateKey32"),
       "sharedKey4" -> SortedMap("sharedKey41" -> "templateValueForSharedKey41", "templateKey42" -> "valueForTemplateKey42")
     ))
-    val jobDefinition = createJobDefinition().copy(jobParameters = userParameters)
-    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
     val jobTemplate = GenericSparkJobTemplate.copy(jobParameters = templateParameters)
+    val jobDefinition = createJobDefinition().copy(jobTemplateId = jobTemplate.id, jobParameters = userParameters)
+    val dagDefinitionJoined = createDagDefinitionJoined(jobDefinition)
 
     // when
     val dagInstanceJoined = JobTemplateResolutionUtil.resolveDagDefinitionJoined(dagDefinitionJoined, Seq(jobTemplate))
@@ -183,7 +183,6 @@ class JobTemplateResolutionUtilTest extends FlatSpec with Matchers {
     JobDefinition(
       dagDefinitionId = 53,
       name = "JobDefinition0",
-      jobType = JobTypes.Spark,
       jobParameters = JobParameters(Map(), Map(), Map()),
       order = 2,
       id = 42

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
@@ -45,13 +45,13 @@ class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
   "getJobTemplateIdByName" should "return the job template id" in {
     insertJobTemplates()
     val result = await(jobTemplateRepository.getJobTemplateIdByName("jobTemplate1"))
-    result shouldBe 100
+    result.get shouldBe 100
   }
 
-  "getJobTemplateIdByName" should "throw an error if the job template name doesn't exist" in {
+  "getJobTemplateIdByName" should "return None if the job template name doesn't exist" in {
     insertJobTemplates()
-    val result = await(jobTemplateRepository.getJobTemplateIdByName("non-existent").failed)
-    result.getMessage should include("non-existent")
+    val result = await(jobTemplateRepository.getJobTemplateIdByName("non-existent"))
+    result shouldBe None
   }
 
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
@@ -38,8 +38,9 @@ class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
 
   "jobTemplateRepository.getJobTemplate" should "return a job template by id" in {
     insertJobTemplates()
-    val result = await(jobTemplateRepository.getJobTemplate(100))
-    result.id shouldBe 100
+    val result = await(jobTemplateRepository.getJobTemplatesByIds(Seq(100)))
+    result should have size 1
+    result.head.id shouldBe 100
   }
 
   "jobTemplateRepository.getJobTemplates" should "return zero job templates when db is empty" in {

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.persistance
+
+import org.scalatest.{FlatSpec, _}
+import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with RepositoryTestBase {
+
+  val jobTemplateRepository: JobTemplateRepository = new JobTemplateRepositoryImpl { override val profile = h2Profile }
+
+  override def beforeAll: Unit = {
+    h2SchemaSetup()
+  }
+
+  override def afterAll: Unit = {
+    h2SchemaDrop()
+  }
+
+  override def afterEach: Unit = {
+    clearData()
+  }
+
+  "dagInstanceRepository.getJobTemplate" should "return a job template by id" in {
+    insertJobTemplates()
+    val result = await(jobTemplateRepository.getJobTemplate(100))
+    result.id shouldBe 100
+  }
+
+  "jobTemplateRepository.getJobTemplates" should "return zero job templates when db is empty" in {
+    val result = await(jobTemplateRepository.getJobTemplates())
+    result.isEmpty shouldBe true
+  }
+
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
@@ -16,7 +16,6 @@
 package za.co.absa.hyperdrive.trigger.persistance
 
 import org.scalatest.{FlatSpec, _}
-import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -36,17 +35,23 @@ class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
     clearData()
   }
 
-  "jobTemplateRepository.getJobTemplate" should "return a job template by id" in {
+  "getJobTemplate" should "return a job template by id" in {
     insertJobTemplates()
     val result = await(jobTemplateRepository.getJobTemplatesByIds(Seq(100)))
     result should have size 1
     result.head.id shouldBe 100
   }
 
-  "jobTemplateRepository.getJobTemplates" should "return zero job templates when db is empty" in {
-    val result = await(jobTemplateRepository.getJobTemplates())
-    result.isEmpty shouldBe true
+  "getJobTemplateIdByName" should "return the job template id" in {
+    insertJobTemplates()
+    val result = await(jobTemplateRepository.getJobTemplateIdByName("jobTemplate1"))
+    result shouldBe 100
   }
 
+  "getJobTemplateIdByName" should "throw an error if the job template name doesn't exist" in {
+    insertJobTemplates()
+    val result = await(jobTemplateRepository.getJobTemplateIdByName("non-existent").failed)
+    result.getMessage should include("non-existent")
+  }
 
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/JobTemplateRepositoryTest.scala
@@ -36,7 +36,7 @@ class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
     clearData()
   }
 
-  "dagInstanceRepository.getJobTemplate" should "return a job template by id" in {
+  "jobTemplateRepository.getJobTemplate" should "return a job template by id" in {
     insertJobTemplates()
     val result = await(jobTemplateRepository.getJobTemplate(100))
     result.id shouldBe 100
@@ -46,5 +46,6 @@ class JobTemplateRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
     val result = await(jobTemplateRepository.getJobTemplates())
     result.isEmpty shouldBe true
   }
+
 
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/RepositoryTestBase.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/RepositoryTestBase.scala
@@ -134,7 +134,7 @@ trait RepositoryTestBase extends Repository {
     val dagRuns: Seq[DagRun] = Seq(dr1, dr2, dr3, dr4, dr5)
 
     val jt1 = JobTemplate(name = "jobTemplate1", jobType = JobTypes.Spark, JobParameters(Map("key" -> "value"), Map("key" -> List("value1", "value2")), Map("key" -> SortedMap("subKey1" -> "value1"))), id = 100)
-    val jt2 = JobTemplate(name = "jobTemplate1", jobType = JobTypes.Shell, JobParameters(Map(), Map(), Map()), id = 101)
+    val jt2 = JobTemplate(name = "jobTemplate2", jobType = JobTypes.Shell, JobParameters(Map(), Map(), Map()), id = 101)
     val jobTemplates = Seq(jt1, jt2)
   }
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/RepositoryTestBase.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/RepositoryTestBase.scala
@@ -39,12 +39,12 @@ trait RepositoryTestBase extends Repository {
       workflowHistoryTable.schema.create,
       dagDefinitionTable.schema.create,
       sensorTable.schema.create,
+      jobTemplateTable.schema.create,
       jobDefinitionTable.schema.create,
       dagInstanceTable.schema.create,
       jobInstanceTable.schema.create,
       eventTable.schema.create,
-      dagRunTable.schema.create,
-      jobTemplateTable.schema.create
+      dagRunTable.schema.create
     )
     run(schema)
   }
@@ -55,12 +55,12 @@ trait RepositoryTestBase extends Repository {
       jobInstanceTable.schema.drop,
       dagInstanceTable.schema.drop,
       jobDefinitionTable.schema.drop,
+      jobTemplateTable.schema.drop,
       sensorTable.schema.drop,
       dagDefinitionTable.schema.drop,
       workflowTable.schema.drop,
       workflowHistoryTable.schema.drop,
-      dagRunTable.schema.drop,
-      jobTemplateTable.schema.drop
+      dagRunTable.schema.drop
     )
     run(schema)
   }
@@ -71,12 +71,12 @@ trait RepositoryTestBase extends Repository {
       jobInstanceTable.delete,
       dagInstanceTable.delete,
       jobDefinitionTable.delete,
+      jobTemplateTable.delete,
       sensorTable.delete,
       dagDefinitionTable.delete,
       workflowTable.delete,
       workflowHistoryTable.delete,
-      dagRunTable.delete,
-      jobTemplateTable.delete
+      dagRunTable.delete
     )
     run(schema)
   }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
@@ -125,7 +125,7 @@ class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers w
   }
 
   private def createJobDefintion(dagDefinitionId: Long): JobDefinition = {
-    JobDefinition(dagDefinitionId, "someJobName", JobTypes.Spark, JobParameters(Map.empty, Map.empty), 1)
+    JobDefinition(dagDefinitionId, -1L, "someJobName", JobTypes.Spark, JobParameters(Map.empty, Map.empty), 1)
   }
 
   private def createDagDefinition(workflowId: Long, id: Long, jobDefinitions: Seq[JobDefinition]) = DagDefinitionJoined(workflowId, jobDefinitions, id)

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
@@ -119,7 +119,7 @@ class EventProcessorTest extends FlatSpec with MockitoSugar with Matchers with B
   }
 
   private def createJobDefintion(dagDefinitionId: Long): JobDefinition = {
-    JobDefinition(dagDefinitionId, -1L, "someJobName", JobTypes.Spark, JobParameters(Map.empty, Map.empty), 1)
+    JobDefinition(dagDefinitionId, -1L, "someJobName", JobParameters(Map.empty, Map.empty), 1)
   }
 
   private def createDagDefinition(workflowId: Long, id: Long, jobDefinitions: Seq[JobDefinition]) = DagDefinitionJoined(workflowId, jobDefinitions, id)

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/EventProcessorTest.scala
@@ -16,28 +16,36 @@
 
 package za.co.absa.hyperdrive.trigger.scheduler
 
+import java.time.LocalDateTime
+
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.{never, verify, when, reset}
+import org.mockito.Mockito.{never, reset, verify, when}
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.JsObject
+import za.co.absa.hyperdrive.trigger.TestUtils.await
+import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateService
 import za.co.absa.hyperdrive.trigger.models._
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes
+import za.co.absa.hyperdrive.trigger.models.enums.{DagInstanceStatuses, JobTypes}
 import za.co.absa.hyperdrive.trigger.persistance.{DagDefinitionRepository, DagInstanceRepository, EventRepository}
 import za.co.absa.hyperdrive.trigger.scheduler.eventProcessor.EventProcessor
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
+class EventProcessorTest extends FlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
   private val eventRepository = mock[EventRepository]
   private val dagDefinitionRepository = mock[DagDefinitionRepository]
   private val dagInstanceRepository = mock[DagInstanceRepository]
+  private val jobTemplateService = mock[JobTemplateService]
+  private val underTest = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository, jobTemplateService)
 
   before {
     reset(eventRepository)
     reset(dagDefinitionRepository)
     reset(dagInstanceRepository)
+    reset(jobTemplateService)
   }
 
   "EventProcessor.eventProcessor" should "persist a dag instances for each event" in {
@@ -49,33 +57,28 @@ class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers w
     val jobDefinition = createJobDefintion(dagDefinitionId)
     val dagDefinition = createDagDefinition(workflowId, dagDefinitionId, Seq(jobDefinition))
 
+    val dagInstanceJoined = createDagInstanceJoined()
     when(eventRepository.getExistEvents(any())(any[ExecutionContext])).thenReturn(Future{Seq()})
     when(dagDefinitionRepository.getJoinedDagDefinition(eqTo(sensorId))(any[ExecutionContext])).thenReturn(Future{Some(dagDefinition)})
+    when(jobTemplateService.resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])).thenReturn(Future{dagInstanceJoined})
     when(dagInstanceRepository.insertJoinedDagInstances(any())(any[ExecutionContext])).thenReturn(Future{(): Unit})
 
-    val underTest = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository)
-
     // when
-    underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)).map(
-      _ => {
-        // then
-        val dagInstanceCaptor = ArgumentCaptor.forClass(classOf[Seq[(DagInstanceJoined, Event)]])
-        verify(dagInstanceRepository).insertJoinedDagInstances(dagInstanceCaptor.capture())(any[ExecutionContext])
+    await(underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)))
 
-        val insertedDagInstances: Seq[(DagInstanceJoined, Event)] = dagInstanceCaptor.getValue
-        insertedDagInstances should have size 1
+    // then
+    val dagInstanceCaptor = ArgumentCaptor.forClass(classOf[Seq[(DagInstanceJoined, Event)]])
+    verify(dagInstanceRepository).insertJoinedDagInstances(dagInstanceCaptor.capture())(any[ExecutionContext])
 
-        val insertedDagInstanceJoined = insertedDagInstances.head._1
-        insertedDagInstanceJoined.workflowId shouldBe workflowId
-        insertedDagInstanceJoined.jobInstances should have size 1
-        insertedDagInstanceJoined.jobInstances.head.jobName shouldBe "someJobName"
-        insertedDagInstanceJoined.jobInstances.head.jobType shouldBe JobTypes.Spark
+    val insertedDagInstances: Seq[(DagInstanceJoined, Event)] = dagInstanceCaptor.getValue
+    insertedDagInstances should have size 1
 
-        val insertedEvent = insertedDagInstances.head._2
-        insertedEvent.sensorEventId shouldBe "sensorEventId"
-        insertedEvent.sensorId shouldBe sensorId
-      }
-    )
+    val insertedDagInstanceJoined = insertedDagInstances.head._1
+    insertedDagInstanceJoined.id shouldBe 3
+
+    val insertedEvent = insertedDagInstances.head._2
+    insertedEvent.sensorEventId shouldBe "sensorEventId"
+    insertedEvent.sensorId shouldBe sensorId
   }
 
   "EventProcessor.eventProcessor" should "not persist a dag instance if the event already exists in DB" in {
@@ -85,17 +88,13 @@ class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers w
 
     when(eventRepository.getExistEvents(any())(any[ExecutionContext])).thenReturn(Future{Seq(event.sensorEventId)})
 
-    val underTest = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository)
-
     // when
-    underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)).map(
-      _ => {
-        // then
-        verify(dagDefinitionRepository, never()).getJoinedDagDefinition(any())(any[ExecutionContext])
-        verify(dagInstanceRepository, never()).insertJoinedDagInstances(any())(any[ExecutionContext])
-        1 shouldBe 1
-      }
-    )
+    await(underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)))
+
+    // then
+    verify(dagDefinitionRepository, never()).getJoinedDagDefinition(any())(any[ExecutionContext])
+    verify(jobTemplateService, never).resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])
+    verify(dagInstanceRepository, never()).insertJoinedDagInstances(any())(any[ExecutionContext])
   }
 
   "EventProcessor.eventProcessor" should "not persist a dag instance if there is no dag definition for event" in {
@@ -106,17 +105,12 @@ class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers w
     when(eventRepository.getExistEvents(any())(any[ExecutionContext])).thenReturn(Future{Seq()})
     when(dagDefinitionRepository.getJoinedDagDefinition(eqTo(sensorId))(any[ExecutionContext])).thenReturn(Future{None})
 
-    val underTest = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository)
-
     // when
-    underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)).map(
-      _ => {
-        // then
-        verify(dagDefinitionRepository).getJoinedDagDefinition(eqTo(sensorId))(any[ExecutionContext])
-        verify(dagInstanceRepository, never()).insertJoinedDagInstances(any())(any[ExecutionContext])
-        1 shouldBe 1
-      }
-    )
+    await(underTest.eventProcessor(Seq(event), Properties(sensorId, Settings(Map.empty, Map.empty), Map.empty)))
+    // then
+    verify(dagDefinitionRepository).getJoinedDagDefinition(eqTo(sensorId))(any[ExecutionContext])
+    verify(jobTemplateService, never).resolveJobTemplate(any[DagDefinitionJoined])(any[ExecutionContext])
+    verify(dagInstanceRepository, never()).insertJoinedDagInstances(any())(any[ExecutionContext])
   }
 
   private def createEvent(sensorId: Long) = {
@@ -129,4 +123,16 @@ class EventProcessorTest extends AsyncFlatSpec with MockitoSugar with Matchers w
   }
 
   private def createDagDefinition(workflowId: Long, id: Long, jobDefinitions: Seq[JobDefinition]) = DagDefinitionJoined(workflowId, jobDefinitions, id)
+
+  private def createDagInstanceJoined() = {
+    DagInstanceJoined(
+      status = DagInstanceStatuses.InQueue,
+      workflowId = 2,
+      jobInstances = Seq(),
+      started = LocalDateTime.now(),
+      finished = None,
+      id = 3
+    )
+  }
+
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/sensors/time/TimeSensorIntegrationTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/sensors/time/TimeSensorIntegrationTest.scala
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
 import org.quartz.JobKey
 import org.quartz.impl.matchers.GroupMatcher
 import org.scalatest._
-import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateFixture
+import za.co.absa.hyperdrive.trigger.api.rest.services.{JobTemplateFixture, JobTemplateService, JobTemplateServiceImpl}
 import za.co.absa.hyperdrive.trigger.models._
 import za.co.absa.hyperdrive.trigger.models.enums.{JobTypes, SensorTypes}
 import za.co.absa.hyperdrive.trigger.persistance._
@@ -54,6 +54,8 @@ class TimeSensorIntegrationTest extends FlatSpec with Matchers with BeforeAndAft
     override val profile = h2Profile
   }
 
+  private val jobTemplateService: JobTemplateService = new JobTemplateServiceImpl(jobTemplateRepository)
+
   override def beforeAll: Unit = {
     h2SchemaSetup()
   }
@@ -67,11 +69,11 @@ class TimeSensorIntegrationTest extends FlatSpec with Matchers with BeforeAndAft
   }
 
   it should "persist an event when the time sensor is fired" in {
-    val processor = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository)
+    val processor = new EventProcessor(eventRepository, dagDefinitionRepository, dagInstanceRepository, jobTemplateService)
     val sensors = new Sensors(processor, sensorRepository)
     val cronExpression = "0/3 * * * * ?"
 
-    val sparkTemplate = JobTemplateFixture.createGenericSparkJobTemplate()
+    val sparkTemplate = JobTemplateFixture.GenericSparkJobTemplate
     val sparkTemplateId = await(jobTemplateRepository.insertJobTemplate(sparkTemplate)).right.get
 
     // Persist workflow, sensor and dagDefinition

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/sensors/time/TimeSensorIntegrationTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/sensors/time/TimeSensorIntegrationTest.scala
@@ -81,9 +81,9 @@ class TimeSensorIntegrationTest extends FlatSpec with Matchers with BeforeAndAft
     val sensor = Sensor(-1L, SensorTypes.Time, properties)
 
     val jobParameters1 = JobParameters(Map("deploymentMode" -> "client", "jobJar" -> "spark-job.jar", "mainClass" -> "TheMainClass"), Map.empty)
-    val jobDefinition1 = JobDefinition(-1L, sparkTemplateId, "Time-Sensor Job 1", JobTypes.Spark, jobParameters1, 1)
+    val jobDefinition1 = JobDefinition(-1L, sparkTemplateId, "Time-Sensor Job 1", jobParameters1, 1)
     val jobParameters2 = JobParameters(Map("deploymentMode" -> "client", "jobJar" -> "spark-job-2.jar", "mainClass" -> "TheMainClass"), Map.empty)
-    val jobDefinition2 = JobDefinition(-1L, sparkTemplateId, "Time-Sensor Job 2", JobTypes.Spark, jobParameters2, 2)
+    val jobDefinition2 = JobDefinition(-1L, sparkTemplateId, "Time-Sensor Job 2", jobParameters2, 2)
 
     val dagDefinitionJoined = DagDefinitionJoined(-1L, Seq(jobDefinition1, jobDefinition2))
     val workflowJoined = WorkflowJoined("Time-Sensor Workflow", true, "some-project", LocalDateTime.now(), None, sensor, dagDefinitionJoined)

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.html
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.html
@@ -23,7 +23,7 @@
     [ngModel]="value"
     (ngModelChange)="modelChanged($event)"
     [required]="partValidationSafe.isRequired">
-    <option *ngFor="let option of options" [value]="option">{{option}}</option>
+    <option *ngFor="let option of options | keyvalue" [value]="option.value">{{option.key}}</option>
   </select>
   <clr-control-error *clrIfError="'required'">{{texts.FORM_VALIDATION_ONE_MUST_BE_SELECTED(name)}}</clr-control-error>
 </clr-select-container>

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.html
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.html
@@ -23,7 +23,8 @@
     [ngModel]="value"
     (ngModelChange)="modelChanged($event)"
     [required]="partValidationSafe.isRequired">
-    <option *ngFor="let option of options | keyvalue" [value]="option.value">{{option.key}}</option>
+    <!-- option.key contains the value, option.value contains the label -->
+    <option *ngFor="let option of options | keyvalue" [value]="option.key">{{option.value}}</option>
   </select>
   <clr-control-error *clrIfError="'required'">{{texts.FORM_VALIDATION_ONE_MUST_BE_SELECTED(name)}}</clr-control-error>
 </clr-select-container>
@@ -31,6 +32,6 @@
 <div *ngIf="isShow" class="clr-form-control clr-row">
   <label class="clr-control-label clr-col-12 clr-col-md-2">{{name}}</label>
   <span class="clr-control-container clr-col-md-10 clr-col-12 breakableSpan">
-    {{value}}
+    {{options.get(value.toString())}}
   </span>
 </div>

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.spec.ts
@@ -57,9 +57,9 @@ describe('SelectPartComponent', () => {
           const newValue = 'oneValue';
           const propertyName = 'property';
           const options = new Map([
-            ['oneKey', newValue],
-            ['twoKey', 'twoValue'],
-            ['threeKey', 'threeValue'],
+            [newValue, 'oneLabel'],
+            ['two', 'twoLabel'],
+            ['three', 'threeLabel'],
           ]);
           const testedSubject = new Subject<WorkflowEntryModel>();
           const subjectSpy = spyOn(testedSubject, 'next');
@@ -90,9 +90,9 @@ describe('SelectPartComponent', () => {
     const newValue = 'threeValue';
     const propertyName = 'property';
     const options = new Map([
-      ['oneKey', oldValue],
+      [oldValue, 'oneLabel'],
       ['two', 'two'],
-      ['threeKey', newValue],
+      [newValue, 'threeLabel'],
     ]);
 
     const testedSubject = new Subject<WorkflowEntryModel>();

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.spec.ts
@@ -54,9 +54,13 @@ describe('SelectPartComponent', () => {
         'should pass with ' + parameter + ' value',
         async(() => {
           const oldValue = parameter;
-          const newValue = 'one';
+          const newValue = 'oneValue';
           const propertyName = 'property';
-          const options = ['one', 'two', 'three'];
+          const options = new Map([
+            ['oneKey', newValue],
+            ['twoKey', 'twoValue'],
+            ['threeKey', 'threeValue'],
+          ]);
           const testedSubject = new Subject<WorkflowEntryModel>();
           const subjectSpy = spyOn(testedSubject, 'next');
           const partValidation = PartValidationFactory.create(true);
@@ -82,10 +86,15 @@ describe('SelectPartComponent', () => {
   });
 
   it('should change value and publish change on user input', async(() => {
-    const oldValue = 'one';
-    const newValue = 'three';
+    const oldValue = 'oneValue';
+    const newValue = 'threeValue';
     const propertyName = 'property';
-    const options = [oldValue, 'two', newValue];
+    const options = new Map([
+      ['oneKey', oldValue],
+      ['two', 'two'],
+      ['threeKey', newValue],
+    ]);
+
     const testedSubject = new Subject<WorkflowEntryModel>();
     const subjectSpy = spyOn(testedSubject, 'next');
     const partValidation = PartValidationFactory.create(true);

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.ts
@@ -48,7 +48,7 @@ export class SelectPartComponent implements OnInit {
       this.options = new Map();
     }
     if (!this.value || this.value == '') {
-      this.modelChanged(this.options.size != 0 ? this.options.values().next().value : '');
+      this.modelChanged(this.options.size != 0 ? this.options.keys().next().value : '');
     }
     this.partValidationSafe = PartValidationFactory.create(!!this.partValidation.isRequired ? this.partValidation.isRequired : true);
   }

--- a/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/dynamic-parts/select-part/select-part.component.ts
@@ -34,7 +34,7 @@ export class SelectPartComponent implements OnInit {
   @Input() name: string;
   @Input() value: string;
   @Input() property: string;
-  @Input() options: string[];
+  @Input() options: Map<string, string>;
   @Input() valueChanges: Subject<WorkflowEntryModel>;
   @Input() partValidation: PartValidation;
   partValidationSafe: PartValidation;
@@ -45,10 +45,10 @@ export class SelectPartComponent implements OnInit {
 
   ngOnInit(): void {
     if (!this.options) {
-      this.options = [];
+      this.options = new Map();
     }
     if (!this.value || this.value == '') {
-      this.modelChanged(this.options.length != 0 ? this.options[0] : '');
+      this.modelChanged(this.options.size != 0 ? this.options.values().next().value : '');
     }
     this.partValidationSafe = PartValidationFactory.create(!!this.partValidation.isRequired ? this.partValidation.isRequired : true);
   }

--- a/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
@@ -46,12 +46,15 @@ describe('JobComponent', () => {
     'switchPartProp',
     'switchPartType',
     PartValidationFactory.create(true),
-    ['optionOne', 'optionTwo'],
+    new Map([
+      ['optionOne', 'optionOne'],
+      ['optionTwoKey', 'optionTwoValue'],
+    ]),
   );
   const jobDynamicPartOne: DynamicFormPart = DynamicFormPartFactory.create('optionOne', [
     FormPartFactory.create('partOne', 'partOne', 'partOne', PartValidationFactory.create(true)),
   ]);
-  const jobDynamicPartTwo: DynamicFormPart = DynamicFormPartFactory.create('optionTwo', [
+  const jobDynamicPartTwo: DynamicFormPart = DynamicFormPartFactory.createKeyValue('optionTwoKey', 'optionTwoValue', [
     FormPartFactory.create('partTwo', 'partTwo', 'partTwo', PartValidationFactory.create(true)),
   ]);
   const workflowFormParts = WorkflowFormPartsModelFactory.create(
@@ -64,7 +67,7 @@ describe('JobComponent', () => {
   const jobsData = [
     JobEntryModelFactory.createWithUuid(0, [
       WorkflowEntryModelFactory.create('jobStaticPart', 'value'),
-      WorkflowEntryModelFactory.create('switchPartProp', 'optionTwo'),
+      WorkflowEntryModelFactory.create('switchPartProp', 'optionTwoValue'),
     ]),
   ];
   const mode = 'mode';

--- a/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
@@ -48,13 +48,13 @@ describe('JobComponent', () => {
     PartValidationFactory.create(true),
     new Map([
       ['optionOne', 'optionOne'],
-      ['optionTwoKey', 'optionTwoValue'],
+      ['optionTwo', 'optionTwoLabel'],
     ]),
   );
   const jobDynamicPartOne: DynamicFormPart = DynamicFormPartFactory.create('optionOne', [
     FormPartFactory.create('partOne', 'partOne', 'partOne', PartValidationFactory.create(true)),
   ]);
-  const jobDynamicPartTwo: DynamicFormPart = DynamicFormPartFactory.createKeyValue('optionTwoKey', 'optionTwoValue', [
+  const jobDynamicPartTwo: DynamicFormPart = DynamicFormPartFactory.createWithLabel('optionTwo', 'optionTwoLabel', [
     FormPartFactory.create('partTwo', 'partTwo', 'partTwo', PartValidationFactory.create(true)),
   ]);
   const workflowFormParts = WorkflowFormPartsModelFactory.create(

--- a/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.spec.ts
@@ -67,7 +67,7 @@ describe('JobComponent', () => {
   const jobsData = [
     JobEntryModelFactory.createWithUuid(0, [
       WorkflowEntryModelFactory.create('jobStaticPart', 'value'),
-      WorkflowEntryModelFactory.create('switchPartProp', 'optionTwoValue'),
+      WorkflowEntryModelFactory.create('switchPartProp', 'optionTwo'),
     ]),
   ];
   const mode = 'mode';

--- a/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.ts
@@ -61,7 +61,7 @@ export class JobComponent implements OnInit, OnDestroy {
   }
 
   getJobTypes(): Map<string, string> {
-    return new Map(this.workflowFormParts.dynamicParts.jobDynamicParts.map((part) => [part.key, part.value]));
+    return new Map(this.workflowFormParts.dynamicParts.jobDynamicParts.map((part) => [part.value, part.label]));
   }
 
   getSelectedJobComponent(): FormPart[] {

--- a/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/jobs/job/job.component.ts
@@ -60,12 +60,12 @@ export class JobComponent implements OnInit, OnDestroy {
     });
   }
 
-  getJobTypes(): string[] {
-    return this.workflowFormParts.dynamicParts.jobDynamicParts.map((part) => part.name);
+  getJobTypes(): Map<string, string> {
+    return new Map(this.workflowFormParts.dynamicParts.jobDynamicParts.map((part) => [part.key, part.value]));
   }
 
   getSelectedJobComponent(): FormPart[] {
-    const jobDynamicPart = this.workflowFormParts.dynamicParts.jobDynamicParts.find((jdp) => jdp.name == this.getSelectedJob());
+    const jobDynamicPart = this.workflowFormParts.dynamicParts.jobDynamicParts.find((jdp) => jdp.value == this.getSelectedJob());
     return jobDynamicPart ? jobDynamicPart.parts : this.workflowFormParts.dynamicParts.jobDynamicParts[0].parts;
   }
 

--- a/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.spec.ts
@@ -35,14 +35,20 @@ describe('SensorComponent', () => {
   const sensorData = [
     { property: 'propertyOne', value: 'valueOne' },
     { property: 'propertyTwo', value: 'valueTwo' },
-    { property: 'switchPartProp', value: 'optionTwo' },
+    { property: 'switchPartProp', value: 'optionTwoValue' },
   ];
   const workflowFormParts = WorkflowFormPartsModelFactory.create(
     [],
-    FormPartFactory.create('switchPartName', 'switchPartProp', 'switchPartType', PartValidationFactory.create(true), [
-      'optionOne',
-      'optionTwo',
-    ]),
+    FormPartFactory.create(
+      'switchPartName',
+      'switchPartProp',
+      'switchPartType',
+      PartValidationFactory.create(true),
+      new Map([
+        ['optionOne', 'optionOne'],
+        ['optionTwoKey', 'optionTwoValue'],
+      ]),
+    ),
     undefined,
     undefined,
     DynamicFormPartsFactory.create(
@@ -50,7 +56,7 @@ describe('SensorComponent', () => {
         DynamicFormPartFactory.create('optionOne', [
           FormPartFactory.create('partOne', 'partOne', 'partOne', PartValidationFactory.create(true)),
         ]),
-        DynamicFormPartFactory.create('optionTwo', [
+        DynamicFormPartFactory.createKeyValue('optionTwoKey', 'optionTwoValue', [
           FormPartFactory.create('partTwo', 'partTwo', 'partTwo', PartValidationFactory.create(true)),
         ]),
       ],

--- a/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.spec.ts
@@ -35,7 +35,7 @@ describe('SensorComponent', () => {
   const sensorData = [
     { property: 'propertyOne', value: 'valueOne' },
     { property: 'propertyTwo', value: 'valueTwo' },
-    { property: 'switchPartProp', value: 'optionTwoValue' },
+    { property: 'switchPartProp', value: 'optionTwo' },
   ];
   const workflowFormParts = WorkflowFormPartsModelFactory.create(
     [],
@@ -46,7 +46,7 @@ describe('SensorComponent', () => {
       PartValidationFactory.create(true),
       new Map([
         ['optionOne', 'optionOne'],
-        ['optionTwoKey', 'optionTwoValue'],
+        ['optionTwo', 'optionTwoLabel'],
       ]),
     ),
     undefined,
@@ -56,7 +56,7 @@ describe('SensorComponent', () => {
         DynamicFormPartFactory.create('optionOne', [
           FormPartFactory.create('partOne', 'partOne', 'partOne', PartValidationFactory.create(true)),
         ]),
-        DynamicFormPartFactory.createKeyValue('optionTwoKey', 'optionTwoValue', [
+        DynamicFormPartFactory.createWithLabel('optionTwo', 'optionTwoLabel', [
           FormPartFactory.create('partTwo', 'partTwo', 'partTwo', PartValidationFactory.create(true)),
         ]),
       ],

--- a/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.ts
@@ -51,15 +51,15 @@ export class SensorComponent implements OnInit, OnDestroy {
     });
   }
 
-  getSensorTypes(): string[] {
-    return this.workflowFormParts.dynamicParts.sensorDynamicParts.map((component) => component.name);
+  getSensorTypes(): Map<string, string> {
+    return new Map(this.workflowFormParts.dynamicParts.sensorDynamicParts.map((component) => [component.key, component.value]));
   }
 
   getSelectedSensorComponent(): FormPart[] {
     const selected = this.sensorData.find((value) => value.property == this.workflowFormParts.sensorSwitchPart.property);
     const selectedSensor = !!selected ? selected.value : undefined;
 
-    const sensorComponent = this.workflowFormParts.dynamicParts.sensorDynamicParts.find((sp) => sp.name == selectedSensor);
+    const sensorComponent = this.workflowFormParts.dynamicParts.sensorDynamicParts.find((sp) => sp.value == selectedSensor);
     return sensorComponent ? sensorComponent.parts : this.workflowFormParts.dynamicParts.sensorDynamicParts[0].parts;
   }
 

--- a/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.ts
+++ b/ui/src/app/components/workflows/workflow-form/sensor/sensor.component.ts
@@ -52,7 +52,7 @@ export class SensorComponent implements OnInit, OnDestroy {
   }
 
   getSensorTypes(): Map<string, string> {
-    return new Map(this.workflowFormParts.dynamicParts.sensorDynamicParts.map((component) => [component.key, component.value]));
+    return new Map(this.workflowFormParts.dynamicParts.sensorDynamicParts.map((component) => [component.value, component.label]));
   }
 
   getSelectedSensorComponent(): FormPart[] {

--- a/ui/src/app/components/workflows/workflow-history/workflow-comparison/workflow-comparison.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow-history/workflow-comparison/workflow-comparison.component.spec.ts
@@ -35,7 +35,7 @@ describe('WorkflowComparisonComponent', () => {
           workflowFormPartsSequences.allDetails,
           workflowFormParts.SENSOR.SENSOR_TYPE,
           workflowFormParts.JOB.JOB_NAME,
-          workflowFormParts.JOB.JOB_TYPE,
+          workflowFormParts.JOB.JOB_TEMPLATE_ID,
           DynamicFormPartsFactory.create([], []),
         ),
         leftWorkflowHistoryData: {

--- a/ui/src/app/components/workflows/workflow/workflow.component.spec.ts
+++ b/ui/src/app/components/workflows/workflow/workflow.component.spec.ts
@@ -54,7 +54,7 @@ describe('WorkflowComponent', () => {
           workflowFormPartsSequences.allDetails,
           workflowFormParts.SENSOR.SENSOR_TYPE,
           workflowFormParts.JOB.JOB_NAME,
-          workflowFormParts.JOB.JOB_TYPE,
+          workflowFormParts.JOB.JOB_TEMPLATE_ID,
           DynamicFormPartsFactory.create([], []),
         ),
         backendValidationErrors: ['validationError'],

--- a/ui/src/app/constants/api.constants.ts
+++ b/ui/src/app/constants/api.constants.ts
@@ -32,5 +32,7 @@ export const api = {
   GET_WORKFLOWS_FROM_HISTORY: '/workflowsFromHistory',
   GET_JOBS_FOR_RUN: '/jobsForRun',
 
+  GET_JOB_TEMPLATE_ID: '/jobTemplateId',
+
   GET_QUARTZ_DETAIL: '/util/quartzDetail',
 };

--- a/ui/src/app/constants/jobTemplates.constants.ts
+++ b/ui/src/app/constants/jobTemplates.constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const jobTemplates = {
+  SHELL_JOB: 'Generic Shell Job',
+  SPARK_JOB: 'Generic Spark Job',
+};

--- a/ui/src/app/constants/jobTemplates.constants.ts
+++ b/ui/src/app/constants/jobTemplates.constants.ts
@@ -16,4 +16,5 @@
 export const jobTemplates = {
   SHELL_JOB: 'Generic Shell Job',
   SPARK_JOB: 'Generic Spark Job',
+  HYPERCONFORMANCE_JOB: 'Hyperconformance Job',
 };

--- a/ui/src/app/constants/workflowFormParts.constants.ts
+++ b/ui/src/app/constants/workflowFormParts.constants.ts
@@ -26,12 +26,12 @@ export const workflowFormParts = {
   },
   JOB: {
     JOB_NAME: FormPartFactory.create('Job name', 'name', 'string-field', PartValidationFactory.create(true, undefined, 1)),
-    JOB_TYPE: FormPartFactory.create('Job type', 'jobType.name', 'select-field', PartValidationFactory.create(true)),
+    JOB_TEMPLATE_ID: FormPartFactory.create('Job template', 'jobTemplateId', 'select-field', PartValidationFactory.create(true)),
   },
 };
 
 export const workflowFormPartsSequences = {
   allDetails: [workflowFormParts.DETAILS.WORKFLOW_NAME, workflowFormParts.DETAILS.PROJECT_NAME, workflowFormParts.DETAILS.IS_ACTIVE],
   allSensors: [workflowFormParts.SENSOR.SENSOR_TYPE],
-  allJobs: [workflowFormParts.JOB.JOB_NAME, workflowFormParts.JOB.JOB_TYPE],
+  allJobs: [workflowFormParts.JOB.JOB_NAME, workflowFormParts.JOB.JOB_TEMPLATE_ID],
 };

--- a/ui/src/app/models/jobDefinition.model.ts
+++ b/ui/src/app/models/jobDefinition.model.ts
@@ -18,7 +18,7 @@ import { JobType } from './jobInstance.model';
 export type JobDefinitionModel = {
   dagDefinitionId: number;
   name: string;
-  jobType: JobType;
+  jobTemplateId: string;
   jobParameters: JobParametersModel;
   order: number;
   id: number;
@@ -43,12 +43,19 @@ export class JobDefinitionModelFactory {
   static create(
     dagDefinitionId = 0,
     name: string,
-    jobType: JobType,
+    jobTemplateId: string,
     jobParameters: JobParametersModel,
     order: number,
     id: number,
   ): JobDefinitionModel {
-    return { dagDefinitionId: dagDefinitionId, name: name, jobType: jobType, jobParameters: jobParameters, order: order, id: id };
+    return {
+      dagDefinitionId: dagDefinitionId,
+      name: name,
+      jobTemplateId: jobTemplateId,
+      jobParameters: jobParameters,
+      order: order,
+      id: id,
+    };
   }
 
   static createEmpty(): JobDefinitionModel {

--- a/ui/src/app/models/workflowData.model.ts
+++ b/ui/src/app/models/workflowData.model.ts
@@ -51,7 +51,7 @@ export class WorkflowDataModel {
   getJobsData(): JobEntryModel[] {
     const jobsData = this.worfklow.dagDefinitionJoined.jobDefinitions.map((job) => {
       const jobStaticPart = workflowFormPartsConsts.JOB.JOB_NAME;
-      const jobDynamicPart = workflowFormPartsConsts.JOB.JOB_TYPE;
+      const jobDynamicPart = workflowFormPartsConsts.JOB.JOB_TEMPLATE_ID;
       const jobDynamicPartValue = get(job, jobDynamicPart.property);
       const jobDynamicOption = this.dynamicParts.jobDynamicParts.find((part) => part.value == jobDynamicPartValue);
       const jobDynamicParts = jobDynamicOption == undefined ? [] : jobDynamicOption.parts;

--- a/ui/src/app/models/workflowData.model.ts
+++ b/ui/src/app/models/workflowData.model.ts
@@ -40,7 +40,7 @@ export class WorkflowDataModel {
   getSensorData(): WorkflowEntryModel[] {
     const sensorType = workflowFormPartsConsts.SENSOR.SENSOR_TYPE;
     const sensorTypeValue = get(this.worfklow.sensor, sensorType.property);
-    const sensorDynamicOption = this.dynamicParts.sensorDynamicParts.find((part) => part.name == sensorTypeValue);
+    const sensorDynamicOption = this.dynamicParts.sensorDynamicParts.find((part) => part.value == sensorTypeValue);
     const sensorDynamicParts = sensorDynamicOption == undefined ? [] : sensorDynamicOption.parts;
     return sensorDynamicParts.concat(sensorType).map((part) => {
       const value = get(this.worfklow.sensor, part.property);
@@ -53,7 +53,7 @@ export class WorkflowDataModel {
       const jobStaticPart = workflowFormPartsConsts.JOB.JOB_NAME;
       const jobDynamicPart = workflowFormPartsConsts.JOB.JOB_TYPE;
       const jobDynamicPartValue = get(job, jobDynamicPart.property);
-      const jobDynamicOption = this.dynamicParts.jobDynamicParts.find((part) => part.name == jobDynamicPartValue);
+      const jobDynamicOption = this.dynamicParts.jobDynamicParts.find((part) => part.value == jobDynamicPartValue);
       const jobDynamicParts = jobDynamicOption == undefined ? [] : jobDynamicOption.parts;
       const jobData = jobDynamicParts.concat(jobDynamicPart, jobStaticPart).map((part) => {
         const value = get(job, part.property);

--- a/ui/src/app/models/workflowFormParts.model.ts
+++ b/ui/src/app/models/workflowFormParts.model.ts
@@ -27,8 +27,8 @@ export type DynamicFormParts = {
 };
 
 export type DynamicFormPart = {
-  key: string;
   value: string;
+  label: string;
   parts: FormPart[];
 };
 
@@ -66,11 +66,11 @@ export class DynamicFormPartsFactory {
 
 export class DynamicFormPartFactory {
   static create(name: string, parts: FormPart[]): DynamicFormPart {
-    return { key: name, value: name, parts: parts };
+    return { value: name, label: name, parts: parts };
   }
 
-  static createKeyValue(key: string, value: string, parts: FormPart[]): DynamicFormPart {
-    return { key: key, value: value, parts: parts };
+  static createWithLabel(value: string, label: string, parts: FormPart[]): DynamicFormPart {
+    return { value: value, label: label, parts: parts };
   }
 }
 

--- a/ui/src/app/models/workflowFormParts.model.ts
+++ b/ui/src/app/models/workflowFormParts.model.ts
@@ -27,7 +27,8 @@ export type DynamicFormParts = {
 };
 
 export type DynamicFormPart = {
-  name: string;
+  key: string;
+  value: string;
   parts: FormPart[];
 };
 
@@ -36,7 +37,7 @@ export type FormPart = {
   property: string;
   type: string;
   partValidation: PartValidation;
-  options?: string[];
+  options?: Map<string, string>;
 };
 
 export class WorkflowFormPartsModelFactory {
@@ -65,12 +66,16 @@ export class DynamicFormPartsFactory {
 
 export class DynamicFormPartFactory {
   static create(name: string, parts: FormPart[]): DynamicFormPart {
-    return { name: name, parts: parts };
+    return { key: name, value: name, parts: parts };
+  }
+
+  static createKeyValue(key: string, value: string, parts: FormPart[]): DynamicFormPart {
+    return { key: key, value: value, parts: parts };
   }
 }
 
 export class FormPartFactory {
-  static create(name: string, property: string, type: string, partValidation: PartValidation, options?: string[]): FormPart {
+  static create(name: string, property: string, type: string, partValidation: PartValidation, options?: Map<string, string>): FormPart {
     return { name: name, property: property, type: type, partValidation: partValidation, options: options };
   }
 }

--- a/ui/src/app/services/workflow/workflow.service.spec.ts
+++ b/ui/src/app/services/workflow/workflow.service.spec.ts
@@ -21,6 +21,7 @@ import { WorkflowService } from './workflow.service';
 import { ProjectModelFactory } from '../../models/project.model';
 import { WorkflowModelFactory } from '../../models/workflow.model';
 import { WorkflowJoinedModelFactory } from '../../models/workflowJoined.model';
+import { jobTemplates } from '../../constants/jobTemplates.constants';
 
 describe('WorkflowService', () => {
   let underTest: WorkflowService;
@@ -138,5 +139,36 @@ describe('WorkflowService', () => {
     const req = httpTestingController.expectOne(api.RUN_WORKFLOWS_JOBS + `?workflowId=${workflowId}`);
     expect(req.request.method).toEqual('PUT');
     req.flush(new Boolean(response));
+  });
+
+  it('getWorkflowDynamicFormParts() should not return no form parts if no template ids are present', () => {
+    underTest.getWorkflowDynamicFormParts().subscribe(
+      (data) => expect(data.jobDynamicParts.length).toEqual(0),
+      (error) => fail(error),
+    );
+
+    const req = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SPARK_JOB));
+    expect(req.request.method).toEqual('GET');
+    req.flush(null);
+    const reqShell = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SHELL_JOB));
+    expect(reqShell.request.method).toEqual('GET');
+    reqShell.flush(null);
+  });
+
+  it('getWorkflowDynamicFormParts() should not return only the shell-job form part if no other template ids are present', () => {
+    underTest.getWorkflowDynamicFormParts().subscribe(
+      (data) => {
+        expect(data.jobDynamicParts.length).toEqual(1);
+        expect(data.jobDynamicParts[0].label).toEqual(jobTemplates.SHELL_JOB);
+      },
+      (error) => fail(error),
+    );
+
+    const req = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SPARK_JOB));
+    expect(req.request.method).toEqual('GET');
+    req.flush(null);
+    const reqShell = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SHELL_JOB));
+    expect(reqShell.request.method).toEqual('GET');
+    reqShell.flush(2);
   });
 });

--- a/ui/src/app/services/workflow/workflow.service.spec.ts
+++ b/ui/src/app/services/workflow/workflow.service.spec.ts
@@ -174,7 +174,7 @@ describe('WorkflowService', () => {
     req.flush(new Boolean(response));
   });
 
-  it('getWorkflowDynamicFormParts() should not return no form parts if no template ids are present', () => {
+  it('getWorkflowDynamicFormParts() should return no form parts if no template ids are present', () => {
     underTest.getWorkflowDynamicFormParts().subscribe(
       (data) => expect(data.jobDynamicParts.length).toEqual(0),
       (error) => fail(error),
@@ -186,9 +186,12 @@ describe('WorkflowService', () => {
     const reqShell = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SHELL_JOB));
     expect(reqShell.request.method).toEqual('GET');
     reqShell.flush(null);
+    const reqHyper = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.HYPERCONFORMANCE_JOB));
+    expect(reqHyper.request.method).toEqual('GET');
+    reqHyper.flush(null);
   });
 
-  it('getWorkflowDynamicFormParts() should not return only the shell-job form part if no other template ids are present', () => {
+  it('getWorkflowDynamicFormParts() should return only the shell-job form part if no other template ids are present', () => {
     underTest.getWorkflowDynamicFormParts().subscribe(
       (data) => {
         expect(data.jobDynamicParts.length).toEqual(1);
@@ -203,5 +206,8 @@ describe('WorkflowService', () => {
     const reqShell = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.SHELL_JOB));
     expect(reqShell.request.method).toEqual('GET');
     reqShell.flush(2);
+    const reqHyper = httpTestingController.expectOne(encodeURI(api.GET_JOB_TEMPLATE_ID + `?name=` + jobTemplates.HYPERCONFORMANCE_JOB));
+    expect(reqHyper.request.method).toEqual('GET');
+    reqHyper.flush(null);
   });
 });

--- a/ui/src/app/services/workflow/workflow.service.ts
+++ b/ui/src/app/services/workflow/workflow.service.ts
@@ -147,7 +147,7 @@ export class WorkflowService {
           ]),
         ],
         [
-          DynamicFormPartFactory.createKeyValue('Generic Spark Job', 'Spark', [
+          DynamicFormPartFactory.createWithLabel('Spark', 'Generic Spark Job', [
             FormPartFactory.create(
               'Job jar',
               'jobParameters.variables.jobJar',
@@ -195,7 +195,7 @@ export class WorkflowService {
               PartValidationFactory.create(false, undefined, 1),
             ),
           ]),
-          DynamicFormPartFactory.createKeyValue('Generic Shell Job', 'Shell', [
+          DynamicFormPartFactory.createWithLabel('Shell', 'Generic Shell Job', [
             FormPartFactory.create(
               'Script location',
               'jobParameters.variables.scriptLocation',

--- a/ui/src/app/services/workflow/workflow.service.ts
+++ b/ui/src/app/services/workflow/workflow.service.ts
@@ -94,6 +94,8 @@ export class WorkflowService {
   }
 
   getWorkflowDynamicFormParts(): Observable<DynamicFormParts> {
+    const sparkJobTemplateId = '1';
+    const shellJobTemplateId = '2';
     return of(
       DynamicFormPartsFactory.create(
         [
@@ -147,7 +149,7 @@ export class WorkflowService {
           ]),
         ],
         [
-          DynamicFormPartFactory.createWithLabel('Spark', 'Generic Spark Job', [
+          DynamicFormPartFactory.createWithLabel(sparkJobTemplateId, 'Generic Spark Job', [
             FormPartFactory.create(
               'Job jar',
               'jobParameters.variables.jobJar',
@@ -195,7 +197,7 @@ export class WorkflowService {
               PartValidationFactory.create(false, undefined, 1),
             ),
           ]),
-          DynamicFormPartFactory.createWithLabel('Shell', 'Generic Shell Job', [
+          DynamicFormPartFactory.createWithLabel(shellJobTemplateId, 'Generic Shell Job', [
             FormPartFactory.create(
               'Script location',
               'jobParameters.variables.scriptLocation',

--- a/ui/src/app/services/workflow/workflow.service.ts
+++ b/ui/src/app/services/workflow/workflow.service.ts
@@ -134,11 +134,16 @@ export class WorkflowService {
   getWorkflowDynamicFormParts(): Observable<DynamicFormParts> {
     const shellTemplateId$ = this.getJobTemplateId(jobTemplates.SHELL_JOB);
     const sparkTemplateId$ = this.getJobTemplateId(jobTemplates.SPARK_JOB);
+    const hyperConformanceTemplateId$ = this.getJobTemplateId(jobTemplates.HYPERCONFORMANCE_JOB);
 
-    return combineLatest([shellTemplateId$, sparkTemplateId$]).pipe(
-      mergeMap(([shellTemplateId, sparkTemplateId]) => {
+    return combineLatest([shellTemplateId$, sparkTemplateId$, hyperConformanceTemplateId$]).pipe(
+      mergeMap(([shellTemplateId, sparkTemplateId, hyperConformanceTemplateId]) => {
         const sensorParts = WorkflowService.getSensorDynamicFormParts();
-        const jobParts = WorkflowService.getJobDynamicFormParts(sparkTemplateId?.toString(), shellTemplateId?.toString());
+        const jobParts = WorkflowService.getJobDynamicFormParts(
+          sparkTemplateId?.toString(),
+          shellTemplateId?.toString(),
+          hyperConformanceTemplateId?.toString(),
+        );
         return of(DynamicFormPartsFactory.create(sensorParts, jobParts));
       }),
     );
@@ -204,13 +209,20 @@ export class WorkflowService {
     ];
   }
 
-  private static getJobDynamicFormParts(sparkTemplateId: string, shellTemplateId: string): DynamicFormPart[] {
+  private static getJobDynamicFormParts(
+    sparkTemplateId: string,
+    shellTemplateId: string,
+    hyperConformanceTemplateId: string,
+  ): DynamicFormPart[] {
     const jobDynamicFormParts = [];
     if (sparkTemplateId != null) {
       jobDynamicFormParts.push(this.getSparkDynamicFormParts(sparkTemplateId));
     }
     if (shellTemplateId != null) {
       jobDynamicFormParts.push(this.getShellDynamicFormParts(shellTemplateId));
+    }
+    if (shellTemplateId != null) {
+      jobDynamicFormParts.push(this.getHyperConformanceDynamicFormParts(hyperConformanceTemplateId));
     }
     return jobDynamicFormParts;
   }
@@ -268,6 +280,35 @@ export class WorkflowService {
         'jobParameters.variables.scriptLocation',
         'string-field',
         PartValidationFactory.create(true, undefined, 1),
+      ),
+    ]);
+  }
+
+  private static getHyperConformanceDynamicFormParts(templateId: string): DynamicFormPart {
+    return DynamicFormPartFactory.createWithLabel(templateId, jobTemplates.HYPERCONFORMANCE_JOB, [
+      FormPartFactory.create(
+        'Additional jars',
+        'jobParameters.maps.additionalJars',
+        'set-field',
+        PartValidationFactory.create(false, undefined, 1),
+      ),
+      FormPartFactory.create(
+        'Additional files',
+        'jobParameters.maps.additionalFiles',
+        'set-field',
+        PartValidationFactory.create(false, undefined, 1),
+      ),
+      FormPartFactory.create(
+        'Additional Spark Config',
+        'jobParameters.keyValuePairs.additionalSparkConfig',
+        'key-value-field',
+        PartValidationFactory.create(false, undefined, 1),
+      ),
+      FormPartFactory.create(
+        'App arguments',
+        'jobParameters.maps.appArguments',
+        'set-field',
+        PartValidationFactory.create(false, undefined, 1),
       ),
     ]);
   }

--- a/ui/src/app/services/workflow/workflow.service.ts
+++ b/ui/src/app/services/workflow/workflow.service.ts
@@ -147,7 +147,7 @@ export class WorkflowService {
           ]),
         ],
         [
-          DynamicFormPartFactory.create('Spark', [
+          DynamicFormPartFactory.createKeyValue('Generic Spark Job', 'Spark', [
             FormPartFactory.create(
               'Job jar',
               'jobParameters.variables.jobJar',
@@ -165,7 +165,10 @@ export class WorkflowService {
               'jobParameters.variables.deploymentMode',
               'select-field',
               PartValidationFactory.create(true),
-              ['cluster', 'client'],
+              new Map([
+                ['cluster', 'cluster'],
+                ['client', 'client'],
+              ]),
             ),
             FormPartFactory.create(
               'Additional jars',
@@ -192,7 +195,7 @@ export class WorkflowService {
               PartValidationFactory.create(false, undefined, 1),
             ),
           ]),
-          DynamicFormPartFactory.create('Shell', [
+          DynamicFormPartFactory.createKeyValue('Generic Shell Job', 'Shell', [
             FormPartFactory.create(
               'Script location',
               'jobParameters.variables.scriptLocation',

--- a/ui/src/app/services/workflow/workflow.service.ts
+++ b/ui/src/app/services/workflow/workflow.service.ts
@@ -221,7 +221,7 @@ export class WorkflowService {
     if (shellTemplateId != null) {
       jobDynamicFormParts.push(this.getShellDynamicFormParts(shellTemplateId));
     }
-    if (shellTemplateId != null) {
+    if (hyperConformanceTemplateId != null) {
       jobDynamicFormParts.push(this.getHyperConformanceDynamicFormParts(hyperConformanceTemplateId));
     }
     return jobDynamicFormParts;

--- a/ui/src/app/stores/workflows/workflows.effects.spec.ts
+++ b/ui/src/app/stores/workflows/workflows.effects.spec.ts
@@ -876,7 +876,7 @@ describe('WorkflowsEffects', () => {
     it('should import workflow', () => {
       const toastrServiceSpy = spyOn(toastrService, 'success');
 
-      const jobDefinition = JobDefinitionModelFactory.create(10, 'name', JobTypeFactory.create('name'), undefined, 0, 10);
+      const jobDefinition = JobDefinitionModelFactory.create(10, 'name', '1', undefined, 0, 10);
       const workflow = WorkflowJoinedModelFactory.create(
         'name',
         true,
@@ -908,8 +908,8 @@ describe('WorkflowsEffects', () => {
                 order: 0,
                 entries: [
                   WorkflowEntryModelFactory.create(
-                    workflowFormParts.JOB.JOB_TYPE.property,
-                    workflow.dagDefinitionJoined.jobDefinitions[0].jobType.name,
+                    workflowFormParts.JOB.JOB_TEMPLATE_ID.property,
+                    workflow.dagDefinitionJoined.jobDefinitions[0].jobTemplateId,
                   ),
                   WorkflowEntryModelFactory.create(
                     workflowFormParts.JOB.JOB_NAME.property,

--- a/ui/src/app/stores/workflows/workflows.effects.spec.ts
+++ b/ui/src/app/stores/workflows/workflows.effects.spec.ts
@@ -91,7 +91,7 @@ describe('WorkflowsEffects', () => {
           workflowFormPartsSequences.allDetails,
           workflowFormPartsConsts.SENSOR.SENSOR_TYPE,
           workflowFormPartsConsts.JOB.JOB_NAME,
-          workflowFormPartsConsts.JOB.JOB_TYPE,
+          workflowFormPartsConsts.JOB.JOB_TEMPLATE_ID,
           DynamicFormPartsFactory.create([], []),
         ),
       },
@@ -147,7 +147,7 @@ describe('WorkflowsEffects', () => {
         workflowFormPartsSequences.allDetails,
         workflowFormPartsConsts.SENSOR.SENSOR_TYPE,
         workflowFormPartsConsts.JOB.JOB_NAME,
-        workflowFormPartsConsts.JOB.JOB_TYPE,
+        workflowFormPartsConsts.JOB.JOB_TEMPLATE_ID,
         dynamicFormParts,
       );
 
@@ -239,7 +239,7 @@ describe('WorkflowsEffects', () => {
     });
 
     it('should initialize workflow', () => {
-      const jobDefinition = JobDefinitionModelFactory.create(10, 'name', JobTypeFactory.create('name'), undefined, 0, 10);
+      const jobDefinition = JobDefinitionModelFactory.create(10, 'name', '1', undefined, 0, 10);
       const workflow = WorkflowJoinedModelFactory.create(
         'name',
         true,
@@ -271,8 +271,8 @@ describe('WorkflowsEffects', () => {
                 order: 0,
                 entries: [
                   WorkflowEntryModelFactory.create(
-                    workflowFormParts.JOB.JOB_TYPE.property,
-                    workflow.dagDefinitionJoined.jobDefinitions[0].jobType.name,
+                    workflowFormParts.JOB.JOB_TEMPLATE_ID.property,
+                    workflow.dagDefinitionJoined.jobDefinitions[0].jobTemplateId,
                   ),
                   WorkflowEntryModelFactory.create(
                     workflowFormParts.JOB.JOB_NAME.property,
@@ -479,7 +479,7 @@ describe('WorkflowsEffects', () => {
         'project',
         undefined,
         SensorModelFactory.create(10, SensorTypeFactory.create('name'), undefined, 10),
-        DagDefinitionJoinedModelFactory.create(10, [JobDefinitionModelFactory.create(10, 'name', { name: 'name' }, undefined, 0, 10)], 10),
+        DagDefinitionJoinedModelFactory.create(10, [JobDefinitionModelFactory.create(10, 'name', '1', undefined, 0, 10)], 10),
         10,
       );
       const createWorkflowSuccessPayload: WorkflowModel = WorkflowModelFactory.create(
@@ -565,7 +565,7 @@ describe('WorkflowsEffects', () => {
         'project',
         undefined,
         SensorModelFactory.create(10, SensorTypeFactory.create('name'), undefined, 10),
-        DagDefinitionJoinedModelFactory.create(10, [JobDefinitionModelFactory.create(10, 'name', { name: 'name' }, undefined, 0, 10)], 10),
+        DagDefinitionJoinedModelFactory.create(10, [JobDefinitionModelFactory.create(10, 'name', '1', undefined, 0, 10)], 10),
         10,
       );
       const updateWorkflowSuccessPayload: WorkflowModel = WorkflowModelFactory.create(
@@ -667,7 +667,7 @@ describe('WorkflowsEffects', () => {
       expect(result.detailsParts).toBe(workflowFormPartsSequences.allDetails);
       expect(result.sensorSwitchPart).toBe(workflowFormPartsConsts.SENSOR.SENSOR_TYPE);
       expect(result.staticJobPart).toBe(workflowFormPartsConsts.JOB.JOB_NAME);
-      expect(result.jobSwitchPart).toBe(workflowFormPartsConsts.JOB.JOB_TYPE);
+      expect(result.jobSwitchPart).toBe(workflowFormPartsConsts.JOB.JOB_TEMPLATE_ID);
     });
   });
 

--- a/ui/src/app/stores/workflows/workflows.effects.ts
+++ b/ui/src/app/stores/workflows/workflows.effects.ts
@@ -386,7 +386,7 @@ export class WorkflowsEffects {
       workflowFormPartsSequences.allDetails,
       workflowFormPartsConsts.SENSOR.SENSOR_TYPE,
       workflowFormPartsConsts.JOB.JOB_NAME,
-      workflowFormPartsConsts.JOB.JOB_TYPE,
+      workflowFormPartsConsts.JOB.JOB_TEMPLATE_ID,
       workflowComponents,
     );
   }


### PR DESCRIPTION
Linked to #236 
Only for demonstration of the next step.

You would need to create a template like this:
```
insert into "job_template" ("name", "job_type", "variables", "maps", "key_value_pairs")
values ('Hyperconformance Job', 'Spark',
'{"jobJar":"driver.jar","mainClass":"za.co.absa.hyperdrive.driver.drivers.CommandLineIngestionDriver","deploymentMode":"cluster"}',
'{"additionalJars":["spark-jobs-2.5.1-SNAPSHOT.jar"],"appArguments":["component.decoder=za.co.absa.hyperdrive.ingestor.implementation.decoder.avro.confluent.ConfluentAvroKafkaStreamDecoder","component.ingestor=Spark","component.manager=za.co.absa.hyperdrive.ingestor.implementation.manager.checkpoint.CheckpointOffsetManager","component.reader=za.co.absa.hyperdrive.ingestor.implementation.reader.kafka.KafkaStreamReader","component.transformer=za.co.absa.enceladus.conformance.HyperConformance","component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.kafka.KafkaStreamWriter"}',
'{}');
```

I believe, the predefined app arguments should not be part of the template, but be grouped as variables. E.g. there is a variable for kafka-reader and it contains component.reader, and the reader config. That way, we could also achieve one level of hierarchy. Templates could consist of variables.

