### PR TITLE
Add github workflows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run tests
+        run: mvn clean test


### PR DESCRIPTION
Alternative build using github actions. We can use this, while the jenkins is down or something doesn't work, like now. Maybe it's also faster than jenkins. Free quota is 500 MB storage and 2000 mins / month, so we might have to be careful not to run into the time limit  in the future.