### PR TITLE
Add basic monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <frontend.maven.plugin.version>1.9.0</frontend.maven.plugin.version>
         <maven.war.plugin.version>2.6</maven.war.plugin.version>
         <commons.lang3.version>3.11</commons.lang3.version>
+        <javamelody.spring.boot.starter.version>1.86.0</javamelody.spring.boot.starter.version>
         <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
 
 
@@ -219,7 +220,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>net.bull.javamelody</groupId>
+            <artifactId>javamelody-spring-boot-starter</artifactId>
+            <version>${javamelody.spring.boot.starter.version}</version>
+        </dependency>
         <!--TESTS-->
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,7 @@ management.endpoints.web.base-path=/admin
 management.endpoints.jmx.exposure.exclude=*
 management.endpoints.web.exposure.include=*
 
+javamelody.management-endpoint-monitoring-enabled=true
 # How will users authenticate. Available options: inmemory, ldap
 auth.mechanism=inmemory
 # INMEMORY authentication: username and password defined here will be used for authentication.
@@ -86,8 +87,8 @@ sparkYarnSink.additionalConfs.spark.shuffle.service.enabled=true
 sparkYarnSink.additionalConfs.spark.dynamicAllocation.enabled=true
 
 #Postgresql properties for connection to trigger metastore
-db.driver=org.postgresql.Driver
-db.url=jdbc:postgresql://
+db.driver=net.bull.javamelody.JdbcDriver
+db.url=jdbc:postgresql://?driver=org.postgresql.Driver
 db.user=
 db.password=
 db.keepAliveConnection=true


### PR DESCRIPTION
Monitoring of SQL queries and method calls would help us pinpoint bottlenecks in our app.

JavaMelody (https://github.com/javamelody/javamelody) is a simple monitoring plugin, which allows us to monitor the usage of SQL queries and spring service methods. It's minimally invasive, just need to add a dependency and a few config changes.

In this PR, the monitoring can be reached under the URL http://localhost:8080/hyperdrive_trigger/admin/monitoring. Like the other admin pages, you need to be authenticated.

Since we don't use Spring's `DataSource`, but work with Slick, we need to configure db driver and URL like this, as explained here: https://github.com/javamelody/javamelody/wiki/UserGuide#7-jdbc

```
db.driver=net.bull.javamelody.JdbcDriver
db.url=jdbc:postgresql://localhost:5432/xyz?driver=org.postgresql.Driver
```
