### PR TITLE
Feature/305 improve cron

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,9 @@
         <scalatest.version>3.0.5</scalatest.version>
         <h2database.version>1.4.200</h2database.version>
         <mockito.version>2.25.0</mockito.version>
-        <cronutils.version>9.1.3</cronutils.version>
+        <cronutils.version>9.1.5</cronutils.version>
+        <cron-parser-core.version>3.5</cron-parser-core.version>
+        <cron-expression-descriptor.version>1.2</cron-expression-descriptor.version>
         <node.version>12.14.1</node.version>
         <npm.version>6.13.4</npm.version>
         <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
@@ -216,6 +218,16 @@
             <groupId>com.cronutils</groupId>
             <artifactId>cron-utils</artifactId>
             <version>${cronutils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.redhogs.cronparser</groupId>
+            <artifactId>cron-parser-core</artifactId>
+            <version>${cron-parser-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>it.burning</groupId>
+            <artifactId>cron-expression-descriptor</artifactId>
+            <version>${cron-expression-descriptor.version}</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,6 @@
         <scalatest.version>3.0.5</scalatest.version>
         <h2database.version>1.4.200</h2database.version>
         <mockito.version>2.25.0</mockito.version>
-        <cronutils.version>9.1.5</cronutils.version>
-        <cron-parser-core.version>3.5</cron-parser-core.version>
         <cron-expression-descriptor.version>1.2</cron-expression-descriptor.version>
         <node.version>12.14.1</node.version>
         <npm.version>6.13.4</npm.version>
@@ -213,16 +211,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
             <version>${spring.ldap.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.cronutils</groupId>
-            <artifactId>cron-utils</artifactId>
-            <version>${cronutils.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.redhogs.cronparser</groupId>
-            <artifactId>cron-parser-core</artifactId>
-            <version>${cron-parser-core.version}</version>
         </dependency>
         <dependency>
             <groupId>it.burning</groupId>

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
@@ -15,65 +15,22 @@
 
 package za.co.absa.hyperdrive.trigger.api.rest.controllers
 
-import java.util.Locale
-import com.cronutils.descriptor.CronDescriptor
-import com.cronutils.model.CronType
-import com.cronutils.model.definition.CronDefinitionBuilder
-import com.cronutils.parser.CronParser
-import it.burning.cron.CronExpressionParser.CronExpressionParseException
-import net.redhogs.cronparser.{CronExpressionDescriptor, Options}
-import it.burning.cron.{CronExpressionDescriptor => CronExpressionDescriptor2}
+import it.burning.cron.CronExpressionParser.{CronExpressionParseException, Options}
+import it.burning.cron.CronExpressionDescriptor
 import org.springframework.web.bind.annotation._
 import za.co.absa.hyperdrive.trigger.models.QuartzExpressionDetail
 
+import java.util.Locale
+
 @RestController
 class UtilController {
-  val parser: CronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ))
-  val descriptor: CronDescriptor = CronDescriptor.instance(Locale.UK)
 
   @GetMapping(path = Array("/util/quartzDetail"))
   def getQuartzDetail(@RequestParam expression: String): QuartzExpressionDetail = {
     try {
-      val expressionDescription = descriptor.describe(parser.parse(expression))
-      QuartzExpressionDetail(
-        expression = expression,
-        isValid = true,
-        explained = expressionDescription
-      )
-    } catch {
-      case e: IllegalArgumentException => {
-        QuartzExpressionDetail(
-          expression = expression,
-          isValid = false,
-          explained = e.getMessage
-        )
-      }
-    }
-  }
-
-  def getQuartzDetail2(@RequestParam expression: String): QuartzExpressionDetail = {
-    try {
-      val description = CronExpressionDescriptor.getDescription(expression, Options.twentyFourHour(), Locale.UK)
-      QuartzExpressionDetail(
-        expression = expression,
-        isValid = true,
-        explained = description
-      )
-    } catch {
-      case e: java.text.ParseException => {
-        QuartzExpressionDetail(
-          expression = expression,
-          isValid = false,
-          explained = e.getMessage
-        )
-      }
-    }
-  }
-
-  def getQuartzDetail3(@RequestParam expression: String): QuartzExpressionDetail = {
-    try {
-      CronExpressionDescriptor2.setDefaultLocale(Locale.UK.toString)
-      val description = CronExpressionDescriptor2.getDescription(expression)
+      val description = CronExpressionDescriptor.getDescription(expression, new Options() {{
+        setLocale(Locale.UK)
+      }})
       QuartzExpressionDetail(
         expression = expression,
         isValid = true,

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
@@ -16,11 +16,13 @@
 package za.co.absa.hyperdrive.trigger.api.rest.controllers
 
 import java.util.Locale
-
 import com.cronutils.descriptor.CronDescriptor
 import com.cronutils.model.CronType
 import com.cronutils.model.definition.CronDefinitionBuilder
 import com.cronutils.parser.CronParser
+import it.burning.cron.CronExpressionParser.CronExpressionParseException
+import net.redhogs.cronparser.{CronExpressionDescriptor, Options}
+import it.burning.cron.{CronExpressionDescriptor => CronExpressionDescriptor2}
 import org.springframework.web.bind.annotation._
 import za.co.absa.hyperdrive.trigger.models.QuartzExpressionDetail
 
@@ -49,4 +51,42 @@ class UtilController {
     }
   }
 
+  def getQuartzDetail2(@RequestParam expression: String): QuartzExpressionDetail = {
+    try {
+      val description = CronExpressionDescriptor.getDescription(expression, Options.twentyFourHour(), Locale.UK)
+      QuartzExpressionDetail(
+        expression = expression,
+        isValid = true,
+        explained = description
+      )
+    } catch {
+      case e: java.text.ParseException => {
+        QuartzExpressionDetail(
+          expression = expression,
+          isValid = false,
+          explained = e.getMessage
+        )
+      }
+    }
+  }
+
+  def getQuartzDetail3(@RequestParam expression: String): QuartzExpressionDetail = {
+    try {
+      CronExpressionDescriptor2.setDefaultLocale(Locale.UK.toString)
+      val description = CronExpressionDescriptor2.getDescription(expression)
+      QuartzExpressionDetail(
+        expression = expression,
+        isValid = true,
+        explained = description
+      )
+    } catch {
+      case e: CronExpressionParseException => {
+        QuartzExpressionDetail(
+          expression = expression,
+          isValid = false,
+          explained = e.getMessage
+        )
+      }
+    }
+  }
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/UtilController.scala
@@ -30,6 +30,7 @@ class UtilController {
     try {
       val description = CronExpressionDescriptor.getDescription(expression, new Options() {{
         setLocale(Locale.UK)
+        setVerbose(true)
       }})
       QuartzExpressionDetail(
         expression = expression,

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
@@ -28,7 +28,7 @@ class UtilControllerTest extends FlatSpec with Matchers with MockitoSugar with B
     val expression = "0 0 2 2 * ?"
 
     // when
-    val result = underTest.getQuartzDetail3(expression)
+    val result = underTest.getQuartzDetail(expression)
 
     // then
     result.expression shouldBe expression
@@ -41,7 +41,7 @@ class UtilControllerTest extends FlatSpec with Matchers with MockitoSugar with B
     val expression = "0 0 2 2 * MON"
 
     // when
-    val result = underTest.getQuartzDetail3(expression)
+    val result = underTest.getQuartzDetail(expression)
 
     // then
     result.expression shouldBe expression

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.controller
+
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import za.co.absa.hyperdrive.trigger.api.rest.controllers.UtilController
+
+class UtilControllerTest extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  private val underTest = new UtilController
+
+  "getQuartzDetail" should "return a human-readable description" in {
+    // given
+    val expression = "0 0 2 2 * ?"
+
+    // when
+    val result = underTest.getQuartzDetail3(expression)
+
+    // then
+    result.expression shouldBe expression
+    result.isValid shouldBe true
+    result.explained shouldBe "At 02:00, on day 2 of the month"
+  }
+
+  it should "return an error description if the cron expression is malformed" in {
+    // given
+    val expression = "0 0 2 2 * MON"
+
+    // when
+    val result = underTest.getQuartzDetail3(expression)
+
+    // then
+    result.expression shouldBe expression
+    result.isValid shouldBe false
+    result.explained shouldBe "Specifying both a Day of Month and Day of Week is not supported. Either one or the other should be declared as \"?\""
+  }
+
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/controller/UtilControllerTest.scala
@@ -23,7 +23,7 @@ import za.co.absa.hyperdrive.trigger.api.rest.controllers.UtilController
 class UtilControllerTest extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
   private val underTest = new UtilController
 
-  "getQuartzDetail" should "return a human-readable description" in {
+  "getQuartzDetail" should "return a human-readable description, incl. month" in {
     // given
     val expression = "0 0 2 2 * ?"
 
@@ -34,6 +34,19 @@ class UtilControllerTest extends FlatSpec with Matchers with MockitoSugar with B
     result.expression shouldBe expression
     result.isValid shouldBe true
     result.explained shouldBe "At 02:00, on day 2 of the month"
+  }
+
+  it should "return a verbose human-readable description" in {
+    // given
+    val expression = "0 0/20 * ? * * *"
+
+    // when
+    val result = underTest.getQuartzDetail(expression)
+
+    // then
+    result.expression shouldBe expression
+    result.isValid shouldBe true
+    result.explained shouldBe "Every 20 minutes, every hour, every day"
   }
 
   it should "return an error description if the cron expression is malformed" in {


### PR DESCRIPTION
Closes #305 

Replaced cronutils with this library https://github.com/voidburn/cron-expression-descriptor, since it seems to be impossible to configure the month text with cronutils.
There is an open issue for a similar issue: https://github.com/jmrozanec/cron-utils/issues/462

The new library has a verbose mode. Here are a few examples
| Expression | cron-expression-descriptor | cron-expression-descriptor verbose | cron-utils |
| --- | --- | --- | --- |
| 0 15 4 ? * 1 * | At 04:15, only on Sunday | At 04:15, every day, only on Sunday | at 04:15 at Sunday day |
| 0 55 * ? * * * | At 55 minutes past the hour | At 55 minutes past the hour, every hour, every day | every hour at minute 55 |
| 0 0/20 * ? * * * | Every 20 minutes | Every 20 minutes, every hour, every day | every 20 minutes |
| 0 0 2 2 * ? * | At 02:00, on day 2 of the month | At 02:00, on day 2 of the month | at 02:00 at 2 day |

While I prefer cron-expression-descriptor for cases 1 and 4, I'm not really happy with the second example, which is a very frequent use case for us, so I'm not completely sure if this PR doesn't make things worse for most workflows
