### PR TITLE
Submission timeout refactoring

### DIFF
--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
@@ -19,13 +19,13 @@ import za.co.absa.hyperdrive.trigger.models.{JobInstance, JobParameters}
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.util.UUID.randomUUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 
 import scala.collection.JavaConverters._
 import org.apache.spark.launcher.{SparkAppHandle, SparkLauncher}
-import scala.concurrent.duration._
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.ahc.StandaloneAhcWSClient
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses._
@@ -52,13 +52,18 @@ object SparkExecutor extends Executor {
     val id = randomUUID().toString
     val ji = jobInstance.copy(executorJobId = Some(id), jobStatus = Submitting)
     updateJob(ji).map { _ =>
-      val start = System.currentTimeMillis()
       val submitTimeOut = SparkExecutorConfig.getSubmitTimeOut
-      val sparkAppHandle = getSparkLauncher(id, ji.jobName, ji.jobParameters).startApplication()
-      while(
-        System.currentTimeMillis() - start <= submitTimeOut &&
-          (sparkAppHandle.getState == SparkAppHandle.State.UNKNOWN || sparkAppHandle.getState == SparkAppHandle.State.CONNECTED)
-      ) Thread.sleep(5.seconds.toMillis)
+      val latch = new CountDownLatch(1)
+      val sparkAppHandle = getSparkLauncher(id, ji.jobName, ji.jobParameters).startApplication(new SparkAppHandle.Listener {
+        override def stateChanged(handle: SparkAppHandle): Unit =
+          if (handle.getState == SparkAppHandle.State.SUBMITTED) {
+            latch.countDown()
+          }
+        override def infoChanged(handle: SparkAppHandle): Unit = {
+          // do nothing
+        }
+      })
+      latch.await(submitTimeOut, TimeUnit.MILLISECONDS)
       sparkAppHandle.kill()
     }
   }


### PR DESCRIPTION
Implements: #426 

Side note: 
sparkAppHandle.kill() does running.destroyForcibly() as we did in the previous implementation
