### PR TITLE
#446: Add job type to job instance parameters

### DIFF
--- a/src/main/resources/db_scripts/db_script_latest.sql
+++ b/src/main/resources/db_scripts/db_script_latest.sql
@@ -25,7 +25,7 @@ create table "workflow" (
 
 create table "job_instance" (
   "job_name" VARCHAR NOT NULL,
-  "job_type" VARCHAR NOT NULL,
+  "job_type_old" VARCHAR,
   "variables_old" VARCHAR DEFAULT '{}',
   "maps_old" VARCHAR DEFAULT '{}',
   "key_value_pairs_old" VARCHAR DEFAULT '{}',

--- a/src/main/resources/db_scripts/liquibase/db.changelog.yml
+++ b/src/main/resources/db_scripts/liquibase/db.changelog.yml
@@ -56,5 +56,8 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: v0.4.3.add-notification-rule.yml
+#  - include:
+#      relativeToChangelogFile: true
+#      file: v0.4.3.add-job-type-to-job-instance-parameters.yml
 
 

--- a/src/main/resources/db_scripts/liquibase/db.changelog.yml
+++ b/src/main/resources/db_scripts/liquibase/db.changelog.yml
@@ -56,8 +56,8 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: v0.4.3.add-notification-rule.yml
-#  - include:
-#      relativeToChangelogFile: true
-#      file: v0.4.3.add-job-type-to-job-instance-parameters.yml
+  - include:
+      relativeToChangelogFile: true
+      file: v0.4.3.add-job-type-to-job-instance-parameters.yml
 
 

--- a/src/main/resources/db_scripts/liquibase/v0.4.3.add-job-type-to-job-instance-parameters.sql
+++ b/src/main/resources/db_scripts/liquibase/v0.4.3.add-job-type-to-job-instance-parameters.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+update job_instance
+set job_parameters = job_parameters::jsonb || ('{"jobType":"' || job_type || '"}' )::jsonb;
+
+alter table job_instance rename column job_type to job_type_old;
+alter table job_instance alter column job_type_old drop not null;
+

--- a/src/main/resources/db_scripts/liquibase/v0.4.3.add-job-type-to-job-instance-parameters.yml
+++ b/src/main/resources/db_scripts/liquibase/v0.4.3.add-job-type-to-job-instance-parameters.yml
@@ -1,0 +1,25 @@
+#
+# Copyright 2018 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+databaseChangeLog:
+  - changeSet:
+      id: v0.4.3.add-job-type-to-job-instance-parameters
+      logicalFilePath: v0.4.3.add-job-type-to-job-instance-parameters
+      author: HyperdriveDevTeam@absa.africa
+      context: default
+      changes:
+        - sqlFile:
+            relativeToChangelogFile: true
+            path: v0.4.3.add-job-type-to-job-instance-parameters.sql

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceService.scala
@@ -60,7 +60,6 @@ class DagInstanceServiceImpl(override val jobTemplateService: JobTemplateService
       }
       JobInstance(
         jobName = resolvedJobDefinition.name,
-        jobType = resolvedJobDefinition.jobType,
         jobParameters = jobParameters,
         jobStatus = initialJobStatus,
         executorJobId = None,

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobInstance.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/JobInstance.scala
@@ -18,11 +18,9 @@ package za.co.absa.hyperdrive.trigger.models
 import java.time.LocalDateTime
 
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.JobStatus
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
 
 case class JobInstance(
   jobName: String,
-  jobType: JobType,
   jobParameters: JobInstanceParameters,
   jobStatus: JobStatus,
   executorJobId: Option[String],
@@ -38,7 +36,6 @@ case class JobInstance(
 case class JobInstanceJoined(
   jobName: String,
   event: Event,
-  jobType: JobType,
   jobParameters: JobInstanceParameters,
   jobStatus: JobStatus,
   executorJobId: Option[String],

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/enums/JobTypes.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/enums/JobTypes.scala
@@ -15,6 +15,8 @@
 
 package za.co.absa.hyperdrive.trigger.models.enums
 
+import play.api.libs.json.{Format, JsPath, JsString, Writes}
+
 object JobTypes {
 
   sealed abstract class JobType(val name: String) {
@@ -26,4 +28,14 @@ object JobTypes {
 
   val jobTypes: Set[JobType] = Set(Spark, Shell)
 
+  def convertJobTypeNameToJobType(jobType: String): JobType = {
+    JobTypes.jobTypes.find(_.name == jobType).getOrElse(
+      throw new Exception(s"Couldn't find JobType: $jobType")
+    )
+  }
+
+  implicit val jobTypesFormat: Format[JobType] = Format[JobType](
+    JsPath.read[String].map(convertJobTypeNameToJobType),
+    Writes[JobType] { jobType => JsString(jobType.name) }
+  )
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobInstanceTable.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/tables/JobInstanceTable.scala
@@ -18,7 +18,6 @@ package za.co.absa.hyperdrive.trigger.models.tables
 import java.time.LocalDateTime
 
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.JobStatus
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
 import za.co.absa.hyperdrive.trigger.models._
 import slick.lifted.{ForeignKeyQuery, ProvenShape}
 
@@ -29,7 +28,6 @@ trait JobInstanceTable {
   final class JobInstanceTable(tag: Tag) extends Table[JobInstance](tag, _tableName = "job_instance") {
 
     def jobName: Rep[String] = column[String]("job_name")
-    def jobType: Rep[JobType] = column[JobType]("job_type")
     def jobParameters: Rep[JobInstanceParameters] = column[JobInstanceParameters]("job_parameters", O.SqlType("JSONB"))
     def jobStatus: Rep[JobStatus] = column[JobStatus]("job_status")
     def executorJobId: Rep[Option[String]] = column[Option[String]]("executor_job_id")
@@ -45,7 +43,6 @@ trait JobInstanceTable {
 
     def * : ProvenShape[JobInstance] = (
       jobName,
-      jobType,
       jobParameters,
       jobStatus,
       executorJobId,
@@ -59,21 +56,19 @@ trait JobInstanceTable {
       jobInstanceTuple =>
         JobInstance.apply(
           jobName = jobInstanceTuple._1,
-          jobType = jobInstanceTuple._2,
-          jobParameters = jobInstanceTuple._3,
-          jobStatus = jobInstanceTuple._4,
-          executorJobId = jobInstanceTuple._5,
-          applicationId = jobInstanceTuple._6,
-          created = jobInstanceTuple._7,
-          updated = jobInstanceTuple._8,
-          order = jobInstanceTuple._9,
-          dagInstanceId = jobInstanceTuple._10,
-          id = jobInstanceTuple._11
+          jobParameters = jobInstanceTuple._2,
+          jobStatus = jobInstanceTuple._3,
+          executorJobId = jobInstanceTuple._4,
+          applicationId = jobInstanceTuple._5,
+          created = jobInstanceTuple._6,
+          updated = jobInstanceTuple._7,
+          order = jobInstanceTuple._8,
+          dagInstanceId = jobInstanceTuple._9,
+          id = jobInstanceTuple._10
         ),
       (jobInstance: JobInstance) =>
         Option(
           jobInstance.jobName,
-          jobInstance.jobType,
           jobInstance.jobParameters,
           jobInstance.jobStatus,
           jobInstance.executorJobId,

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceServiceTest.scala
@@ -54,7 +54,6 @@ class DagInstanceServiceTest extends AsyncFlatSpec with Matchers with MockitoSug
 
     val jobInstance1 = dagInstance.jobInstances.head
     val jobDefinition1 = resolvedJobDefinitions.head
-    jobInstance1.jobType shouldBe jobDefinition1.jobType
     jobInstance1.jobName shouldBe jobDefinition1.name
     jobInstance1.jobParameters shouldBe SparkParameters(jobDefinition1.jobParameters)
     jobInstance1.jobStatus shouldBe JobStatuses.InQueue
@@ -66,7 +65,6 @@ class DagInstanceServiceTest extends AsyncFlatSpec with Matchers with MockitoSug
 
     val jobInstance2 = dagInstance.jobInstances(1)
     val jobDefinition2 = resolvedJobDefinitions(1)
-    jobInstance2.jobType shouldBe jobDefinition2.jobType
     jobInstance2.jobName shouldBe jobDefinition2.name
     jobInstance2.jobParameters shouldBe ShellParameters(jobDefinition2.jobParameters)
     jobInstance2.order shouldBe jobDefinition2.order

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/shell/ShellExecutorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/shell/ShellExecutorTest.scala
@@ -26,7 +26,6 @@ import za.co.absa.hyperdrive.trigger.models.{JobInstance, ShellParameters}
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.{Failed, InQueue, Lost, Running, Submitting, Succeeded}
-import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.Shell
 import za.co.absa.hyperdrive.trigger.scheduler.utilities.ShellExecutorConfig
 
 import scala.concurrent.{Await, Future}
@@ -40,7 +39,6 @@ class ShellExecutorTest extends FlatSpec with Matchers with BeforeAndAfterAll wi
   private val testScriptLocation = "testShellScript.sh"
   private val testJobInstance = JobInstance(
     jobName = "jobName",
-    jobType = Shell,
     jobParameters = ShellParameters(scriptLocation = ""),
     jobStatus = InQueue,
     executorJobId = None,

--- a/ui/src/app/components/runs/run-detail/run-detail.component.html
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.html
@@ -25,7 +25,7 @@
 
     <clr-dg-row *ngFor="let jobInstance of jobInstances">
       <clr-dg-cell>{{jobInstance.jobName}}</clr-dg-cell>
-      <clr-dg-cell>{{jobInstance.jobType.name}}</clr-dg-cell>
+      <clr-dg-cell>{{jobInstance.jobParameters.jobType.name}}</clr-dg-cell>
       <clr-dg-cell>{{jobInstance.created | date:'medium'}}</clr-dg-cell>
       <clr-dg-cell>{{jobInstance.updated | date:'medium'}}</clr-dg-cell>
       <clr-dg-cell [ngSwitch]="jobInstance.jobStatus.name">

--- a/ui/src/app/models/jobInstance.model.ts
+++ b/ui/src/app/models/jobInstance.model.ts
@@ -18,7 +18,7 @@ import { JobType } from './jobType.model';
 export type JobInstanceModel = {
   id: number;
   jobName: string;
-  jobType: JobType;
+  jobParameters: JobInstanceParametersModel;
   applicationId: string;
   created: Date;
   updated: Date;
@@ -34,7 +34,7 @@ export class JobInstanceModelFactory {
   static create(
     id: number,
     jobName: string,
-    jobType: JobType,
+    jobParameters: JobInstanceParametersModel,
     applicationId: string,
     created: Date,
     updated: Date,
@@ -44,7 +44,7 @@ export class JobInstanceModelFactory {
     return {
       id: id,
       jobName: jobName,
-      jobType: jobType,
+      jobParameters: jobParameters,
       applicationId: applicationId,
       created: created,
       updated: updated,
@@ -57,5 +57,17 @@ export class JobInstanceModelFactory {
 export class JobStatusFactory {
   static create(name: string): JobStatus {
     return { name: name };
+  }
+}
+
+export type JobInstanceParametersModel = {
+  jobType: JobType;
+};
+
+export class JobInstanceParametersModelFactory {
+  static create(jobType: JobType): JobInstanceParametersModel {
+    return {
+      jobType: jobType,
+    };
   }
 }

--- a/ui/src/app/stores/runs/runs.effects.spec.ts
+++ b/ui/src/app/stores/runs/runs.effects.spec.ts
@@ -25,7 +25,12 @@ import * as RunsActions from './runs.actions';
 import { GetDagRunDetail, GetDagRuns } from './runs.actions';
 
 import { DagRunModel, DagRunModelFactory } from '../../models/dagRuns/dagRun.model';
-import { JobInstanceModel, JobInstanceModelFactory, JobStatusFactory } from '../../models/jobInstance.model';
+import {
+  JobInstanceModel,
+  JobInstanceModelFactory,
+  JobInstanceParametersModelFactory,
+  JobStatusFactory,
+} from '../../models/jobInstance.model';
 import { TableSearchResponseModel } from '../../models/search/tableSearchResponse.model';
 import { SortAttributesModel } from '../../models/search/sortAttributes.model';
 import { JobTypeFactory } from '../../models/jobType.model';
@@ -95,7 +100,7 @@ describe('RunsEffects', () => {
       const jobInstanceA: JobInstanceModel = JobInstanceModelFactory.create(
         id,
         'jobName0',
-        JobTypeFactory.create('JobType'),
+        JobInstanceParametersModelFactory.create(JobTypeFactory.create('JobType')),
         'applicationId',
         new Date(Date.now()),
         new Date(Date.now()),
@@ -105,7 +110,7 @@ describe('RunsEffects', () => {
       const jobInstanceB: JobInstanceModel = JobInstanceModelFactory.create(
         id,
         'jobName1',
-        JobTypeFactory.create('JobType1'),
+        JobInstanceParametersModelFactory.create(JobTypeFactory.create('JobType1')),
         'applicationId',
         new Date(Date.now()),
         new Date(Date.now()),
@@ -115,7 +120,7 @@ describe('RunsEffects', () => {
       const jobInstanceC: JobInstanceModel = JobInstanceModelFactory.create(
         id,
         'jobName2',
-        JobTypeFactory.create('JobType2'),
+        JobInstanceParametersModelFactory.create(JobTypeFactory.create('JobType2')),
         'applicationId',
         new Date(Date.now()),
         new Date(Date.now()),

--- a/ui/src/app/stores/runs/runs.reducers.spec.ts
+++ b/ui/src/app/stores/runs/runs.reducers.spec.ts
@@ -23,7 +23,12 @@ import {
   GetDagRunsSuccess,
 } from './runs.actions';
 import { DagRunModel, DagRunModelFactory } from '../../models/dagRuns/dagRun.model';
-import { JobInstanceModel, JobInstanceModelFactory, JobStatusFactory } from '../../models/jobInstance.model';
+import {
+  JobInstanceModel,
+  JobInstanceModelFactory,
+  JobInstanceParametersModelFactory,
+  JobStatusFactory,
+} from '../../models/jobInstance.model';
 import { TableSearchResponseModel } from '../../models/search/tableSearchResponse.model';
 import { SortAttributesModel } from '../../models/search/sortAttributes.model';
 import { JobTypeFactory } from '../../models/jobType.model';
@@ -94,7 +99,7 @@ describe('RunsReducers', () => {
       JobInstanceModelFactory.create(
         0,
         'jobName0',
-        JobTypeFactory.create('JobType'),
+        JobInstanceParametersModelFactory.create(JobTypeFactory.create('JobType')),
         'applicationId',
         new Date(Date.now()),
         new Date(Date.now()),


### PR DESCRIPTION
Implements small part of: #446 

- Need for refactoring because Json format doesn't know how to serialize/deserialize classes like this: 
trait ABTrait
case class A(a: Option[String]) extends ABTrait
case class B(b: Option[String]) extends ABTrait
in case of field a or b is NONE.
