### PR TITLE
Add timeout config for yarn connection health indicator

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,7 @@ management.endpoint.health.show-details=always
 javamelody.management-endpoint-monitoring-enabled=true
 
 # Health check settings
-health.databaseConnection.timeoutMillis=120000
+health.databaseConnection.timeoutMillis=60000
 health.yarnConnection.testEndpoint=/cluster/cluster
 health.yarnConnection.timeoutMillis=60000
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,7 @@ javamelody.management-endpoint-monitoring-enabled=true
 # Health check settings
 health.databaseConnection.timeoutMillis=120000
 health.yarnConnection.testEndpoint=/cluster/cluster
+health.yarnConnection.timeoutMillis=120000
 
 # How will users authenticate. Available options: inmemory, ldap
 auth.mechanism=inmemory

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,7 @@ javamelody.management-endpoint-monitoring-enabled=true
 # Health check settings
 health.databaseConnection.timeoutMillis=120000
 health.yarnConnection.testEndpoint=/cluster/cluster
-health.yarnConnection.timeoutMillis=120000
+health.yarnConnection.timeoutMillis=60000
 
 # How will users authenticate. Available options: inmemory, ldap
 auth.mechanism=inmemory

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/health/YarnConnectionHealthIndicator.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/health/YarnConnectionHealthIndicator.scala
@@ -34,6 +34,7 @@ class YarnConnectionHealthIndicator extends HealthIndicator {
     Try(new URL(s"$yarnBaseUrl/$yarnTestEndpoint")).flatMap(url =>
       Try({
         val connection = url.openConnection().asInstanceOf[HttpURLConnection]
+        HealthConfig.yarnConnectionTimeoutMillisOpt.foreach(connection.setConnectTimeout)
         connection.getResponseCode == successCode
       })
     ) match {

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/utilities/Configs.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/utilities/Configs.scala
@@ -122,8 +122,11 @@ object JobDefinitionConfig {
 object HealthConfig {
   lazy val databaseConnectionTimeoutMillis: Int =
     Try(Configs.conf.getInt("health.databaseConnection.timeoutMillis")).getOrElse(120000)
-  lazy val yarnConnectionTestEndpoint: String =
+  lazy val yarnConnectionTestEndpoint: String = {
     Configs.conf.getString("health.yarnConnection.testEndpoint")
+  }
+  lazy val yarnConnectionTimeoutMillisOpt: Option[Int] =
+    Try(Configs.conf.getInt("health.yarnConnection.timeoutMillis")).toOption
 }
 
 object ApplicationConfig {


### PR DESCRIPTION
Closes #470 

**New application property**
```
health.yarnConnection.timeoutMillis
```
Default value = 60000