### PR TITLE
#466: Kill running Spark Job

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -104,6 +104,7 @@ sparkYarnSink.additionalConfs.spark.yarn.principal=
 sparkYarnSink.additionalConfs.spark.shuffle.service.enabled=true
 sparkYarnSink.additionalConfs.spark.dynamicAllocation.enabled=true
 sparkYarnSink.executablesFolder=/
+sparkYarnSink.userUsedToKillJob=
 
 #Postgresql properties for connection to trigger metastore
 db.driver=net.bull.javamelody.JdbcDriver

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobInstanceController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobInstanceController.scala
@@ -32,8 +32,8 @@ class JobInstanceController @Inject()(jobInstanceService: JobInstanceService) {
     jobInstanceService.getJobInstances(dagInstanceId).toJava.toCompletableFuture
   }
 
-  @PostMapping(path = Array("/jobInstances"))
-  def killJob(@RequestParam applicationId: String): CompletableFuture[Boolean] = {
+  @PostMapping(path = Array("/jobInstances/{applicationId}/kill"))
+  def killJob(@PathVariable applicationId: String): CompletableFuture[Boolean] = {
     jobInstanceService.killJob(applicationId).toJava.toCompletableFuture
   }
 

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobInstanceController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/JobInstanceController.scala
@@ -16,7 +16,6 @@
 package za.co.absa.hyperdrive.trigger.api.rest.controllers
 
 import java.util.concurrent.CompletableFuture
-
 import za.co.absa.hyperdrive.trigger.api.rest.services.JobInstanceService
 import za.co.absa.hyperdrive.trigger.models.JobInstance
 import javax.inject.Inject
@@ -31,6 +30,11 @@ class JobInstanceController @Inject()(jobInstanceService: JobInstanceService) {
   @GetMapping(path = Array("/jobInstances"))
   def getJobInstances(@RequestParam dagInstanceId: Long): CompletableFuture[Seq[JobInstance]] = {
     jobInstanceService.getJobInstances(dagInstanceId).toJava.toCompletableFuture
+  }
+
+  @PostMapping(path = Array("/jobInstances"))
+  def killJob(@RequestParam applicationId: String): CompletableFuture[Boolean] = {
+    jobInstanceService.killJob(applicationId).toJava.toCompletableFuture
   }
 
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/WSClientProvider.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/WSClientProvider.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.utils
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import play.api.libs.ws.StandaloneWSClient
+import play.api.libs.ws.ahc.StandaloneAhcWSClient
+
+object WSClientProvider {
+  private val wsClient: StandaloneWSClient = StandaloneAhcWSClient()(ActorMaterializer()(ActorSystem()))
+
+  def getWSClient: StandaloneWSClient = {
+    wsClient
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
@@ -21,13 +21,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import java.util.UUID.randomUUID
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-
 import scala.collection.JavaConverters._
 import org.apache.spark.launcher.{SparkAppHandle, SparkLauncher}
 import play.api.libs.json.{JsValue, Json}
-import play.api.libs.ws.ahc.StandaloneAhcWSClient
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses._
 import za.co.absa.hyperdrive.trigger.scheduler.executors.Executor
 import za.co.absa.hyperdrive.trigger.scheduler.utilities.SparkExecutorConfig
@@ -35,10 +31,9 @@ import za.co.absa.hyperdrive.trigger.scheduler.utilities.JobDefinitionConfig.{Ke
 import play.api.libs.ws.JsonBodyReadables._
 import za.co.absa.hyperdrive.trigger.scheduler.executors.spark.{FinalStatuses => YarnFinalStatuses}
 import org.slf4j.LoggerFactory
+import za.co.absa.hyperdrive.trigger.api.rest.utils.WSClientProvider
 
 object SparkExecutor extends Executor[SparkInstanceParameters] {
-  private val wsClient = StandaloneAhcWSClient()(ActorMaterializer()(ActorSystem()))
-
   override def execute(jobInstance: JobInstance, jobParameters: SparkInstanceParameters, updateJob: JobInstance => Future[Unit])
                       (implicit executionContext: ExecutionContext): Future[Unit] = {
     jobInstance.executorJobId match {
@@ -70,7 +65,7 @@ object SparkExecutor extends Executor[SparkInstanceParameters] {
 
   private def updateJobStatus(executorJobId: String, jobInstance: JobInstance, updateJob: JobInstance => Future[Unit])
                              (implicit executionContext: ExecutionContext): Future[Unit] = {
-    wsClient.url(getStatusUrl(executorJobId)).get().map { response =>
+    WSClientProvider.getWSClient.url(getStatusUrl(executorJobId)).get().map { response =>
       (Json.fromJson[AppsResponse](response.body[JsValue]).asOpt match {
         case Some(asd) => asd.apps.app
         case None => Seq.empty

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/utilities/Configs.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/utilities/Configs.scala
@@ -112,6 +112,8 @@ object SparkExecutorConfig {
     Configs.getMapFromConf("sparkYarnSink.additionalConfs")
   val getExecutablesFolder: String =
     Configs.conf.getString("sparkYarnSink.executablesFolder")
+  val getUserUsedToKillJob: String =
+    Try(Configs.conf.getString("sparkYarnSink.userUsedToKillJob")).getOrElse("Unknown")
 }
 
 object JobDefinitionConfig {

--- a/ui/src/app/components/runs/run-detail/run-detail.component.html
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.html
@@ -14,6 +14,15 @@
   -->
 
   <clr-datagrid [clrDgLoading]="loading">
+
+    <clr-dg-action-bar *ngIf="canKillJob()">
+      <div class="btn-group">
+        <button class="btn btn-danger btn-sm" (click)="killJob()">
+          Kill running spark job
+        </button>
+      </div>
+    </clr-dg-action-bar>
+
     <clr-dg-column>Job Name</clr-dg-column>
     <clr-dg-column>Type</clr-dg-column>
     <clr-dg-column>Created</clr-dg-column>

--- a/ui/src/app/constants/api.constants.ts
+++ b/ui/src/app/constants/api.constants.ts
@@ -21,6 +21,7 @@ export const api = {
 
   DAG_RUN_SEARCH: '/dagRuns/search',
   JOB_INSTANCES: '/jobInstances',
+  KILL_JOB: '/jobInstances',
 
   GET_PROJECTS: '/workflows/projects',
   GET_WORKFLOW: '/workflow',

--- a/ui/src/app/constants/api.constants.ts
+++ b/ui/src/app/constants/api.constants.ts
@@ -21,7 +21,7 @@ export const api = {
 
   DAG_RUN_SEARCH: '/dagRuns/search',
   JOB_INSTANCES: '/jobInstances',
-  KILL_JOB: '/jobInstances',
+  KILL_JOB: '/jobInstances/{applicationId}/kill',
 
   GET_PROJECTS: '/workflows/projects',
   GET_WORKFLOW: '/workflow',

--- a/ui/src/app/constants/texts.constants.ts
+++ b/ui/src/app/constants/texts.constants.ts
@@ -51,6 +51,12 @@ export const texts = {
   RUN_WORKFLOWS_SUCCESS_NOTIFICATION: 'Workflows have been submitted.',
   RUN_WORKFLOWS_FAILURE_NOTIFICATION: "Sorry, workflows couldn't be submitted. Please try again.",
 
+  KILL_JOB_CONFIRMATION_TITLE: 'Kill running job',
+  KILL_JOB_CONFIRMATION_CONTENT:
+    'Are you sure you want to kill running job? The operation cannot be reverted and operation may not take effect.',
+  KILL_JOB_SUCCESS_NOTIFICATION: 'Kill job request passed, but it does not mean that job is killed. Please refresh page and verify status.',
+  KILL_JOB_FAILURE_NOTIFICATION: 'Sorry, something went wrong. Try again.',
+
   CREATE_WORKFLOW_CONFIRMATION_TITLE: 'Create workflow',
   CREATE_WORKFLOW_CONFIRMATION_CONTENT: 'Are you sure you want to create new workflow?',
   CREATE_WORKFLOW_SUCCESS_NOTIFICATION: 'Workflow has been created.',

--- a/ui/src/app/constants/texts.constants.ts
+++ b/ui/src/app/constants/texts.constants.ts
@@ -52,9 +52,9 @@ export const texts = {
   RUN_WORKFLOWS_FAILURE_NOTIFICATION: "Sorry, workflows couldn't be submitted. Please try again.",
 
   KILL_JOB_CONFIRMATION_TITLE: 'Kill running job',
-  KILL_JOB_CONFIRMATION_CONTENT:
-    'Are you sure you want to kill running job? The operation cannot be reverted and operation may not take effect.',
-  KILL_JOB_SUCCESS_NOTIFICATION: 'Kill job request passed, but it does not mean that job is killed. Please refresh page and verify status.',
+  KILL_JOB_CONFIRMATION_CONTENT: 'Are you sure you want to kill running job? The operation cannot be reverted!',
+  KILL_JOB_SUCCESS_NOTIFICATION:
+    'Request to kill the job has been submitted. Please refresh the page after a few seconds and verify its status.',
   KILL_JOB_FAILURE_NOTIFICATION: 'Sorry, something went wrong. Try again.',
 
   CREATE_WORKFLOW_CONFIRMATION_TITLE: 'Create workflow',

--- a/ui/src/app/services/dagRun/dag-run.service.spec.ts
+++ b/ui/src/app/services/dagRun/dag-run.service.spec.ts
@@ -63,7 +63,7 @@ describe('DagRunService', () => {
       (error) => fail(error),
     );
 
-    const req = httpTestingController.expectOne(api.KILL_JOB + '?applicationId=' + applicationId);
+    const req = httpTestingController.expectOne(api.KILL_JOB.replace('{applicationId}', applicationId.toString()));
     expect(req.request.method).toEqual('POST');
     req.flush(new Boolean(true));
   });

--- a/ui/src/app/services/dagRun/dag-run.service.spec.ts
+++ b/ui/src/app/services/dagRun/dag-run.service.spec.ts
@@ -54,4 +54,17 @@ describe('DagRunService', () => {
     expect(req.request.method).toEqual('GET');
     req.flush([...jobInstances]);
   });
+
+  it('killJob() should call kill job rest api', () => {
+    const applicationId = 'application_id';
+    const response = true;
+    underTest.killJob(applicationId).subscribe(
+      (data) => expect(data).toEqual(response),
+      (error) => fail(error),
+    );
+
+    const req = httpTestingController.expectOne(api.KILL_JOB + '?applicationId=' + applicationId);
+    expect(req.request.method).toEqual('POST');
+    req.flush(new Boolean(true));
+  });
 });

--- a/ui/src/app/services/dagRun/dag-run.service.ts
+++ b/ui/src/app/services/dagRun/dag-run.service.ts
@@ -55,4 +55,9 @@ export class DagRunService {
         }),
       );
   }
+
+  killJob(applicationId: string): Observable<boolean> {
+    const params = new HttpParams().set('applicationId', applicationId);
+    return this.httpClient.post<boolean>(api.KILL_JOB, {}, { params: params, observe: 'response' }).pipe(map((_) => _.body));
+  }
 }

--- a/ui/src/app/services/dagRun/dag-run.service.ts
+++ b/ui/src/app/services/dagRun/dag-run.service.ts
@@ -57,7 +57,8 @@ export class DagRunService {
   }
 
   killJob(applicationId: string): Observable<boolean> {
-    const params = new HttpParams().set('applicationId', applicationId);
-    return this.httpClient.post<boolean>(api.KILL_JOB, {}, { params: params, observe: 'response' }).pipe(map((_) => _.body));
+    return this.httpClient
+      .post<boolean>(api.KILL_JOB.replace('{applicationId}', applicationId.toString()), {}, { observe: 'response' })
+      .pipe(map((_) => _.body));
   }
 }

--- a/ui/src/app/stores/runs/runs.actions.ts
+++ b/ui/src/app/stores/runs/runs.actions.ts
@@ -27,6 +27,8 @@ export const GET_DAG_RUN_DETAIL = 'GET_DAG_RUN_DETAIL';
 export const GET_DAG_RUN_DETAIL_SUCCESS = 'GET_DAG_RUN_DETAIL_SUCCESS';
 export const GET_DAG_RUN_DETAIL_FAILURE = 'GET_DAG_RUN_DETAIL_FAILURE';
 
+export const KILL_JOB = 'KILL_JOB';
+
 export class GetDagRuns implements Action {
   readonly type = GET_DAG_RUNS;
   constructor(public payload: TableSearchRequestModel) {}
@@ -55,10 +57,16 @@ export class GetDagRunDetailFailure implements Action {
   readonly type = GET_DAG_RUN_DETAIL_FAILURE;
 }
 
+export class KillJob implements Action {
+  readonly type = KILL_JOB;
+  constructor(public payload: { dagRunId: number; applicationId: string }) {}
+}
+
 export type RunsActions =
   | GetDagRuns
   | GetDagRunsSuccess
   | GetDagRunsFailure
   | GetDagRunDetail
   | GetDagRunDetailSuccess
-  | GetDagRunDetailFailure;
+  | GetDagRunDetailFailure
+  | KillJob;


### PR DESCRIPTION
Implements: #466 - Kill running Spark Job

User is only able to kill Running Spark job with application id from yarn

New application property:
sparkYarnSink.userUsedToKillJob