### PR TITLE
#523: Check if kafka topic exist

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ spring.mail.port=
 #Kafka sensor properties.
 kafkaSource.group.id.prefix=hyper_drive
 kafkaSource.poll.duration=500
+kafkaSource.connectionTimeoutMillis=10000
 kafkaSource.properties.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 kafkaSource.properties.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 kafkaSource.properties.max.poll.records=100

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
@@ -24,8 +24,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 @RestController
 class KafkaController @Inject()(kafkaService: KafkaService) {
-  @GetMapping(path = Array("/doesKafkaTopicExist"))
-  def doesKafkaTopicExist(@RequestParam kafkaTopicName: String, @RequestParam servers: Array[String]): CompletableFuture[Boolean] = {
-    kafkaService.doesKafkaTopicExist(kafkaTopicName, servers).toJava.toCompletableFuture
+  @GetMapping(path = Array("/topics/{topicName}/exists"))
+  def existsTopic(@PathVariable topicName: String, @RequestParam servers: Array[String]): CompletableFuture[Boolean] = {
+    kafkaService.existsTopic(topicName, servers).toJava.toCompletableFuture
   }
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.controllers
+
+import org.springframework.web.bind.annotation._
+import za.co.absa.hyperdrive.trigger.api.rest.services.KafkaService
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@RestController
+class KafkaController @Inject()(kafkaService: KafkaService) {
+  @GetMapping(path = Array("/doesKafkaTopicExist"))
+  def doesKafkaTopicExist(@RequestParam kafkaTopicName: String, @RequestParam servers: Array[String]): CompletableFuture[Boolean] = {
+    kafkaService.doesKafkaTopicExist(kafkaTopicName, servers).toJava.toCompletableFuture
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/controllers/KafkaController.scala
@@ -15,17 +15,38 @@
 
 package za.co.absa.hyperdrive.trigger.api.rest.controllers
 
+import org.springframework.core.MethodParameter
 import org.springframework.web.bind.annotation._
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import za.co.absa.hyperdrive.trigger.api.rest.services.KafkaService
+
 import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
+import scala.util.{Failure, Success, Try}
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @RestController
 class KafkaController @Inject()(kafkaService: KafkaService) {
   @GetMapping(path = Array("/topics/{topicName}/exists"))
-  def existsTopic(@PathVariable topicName: String, @RequestParam servers: Array[String]): CompletableFuture[Boolean] = {
-    kafkaService.existsTopic(topicName, servers).toJava.toCompletableFuture
+  def existsTopic(@PathVariable topicName: String, @RequestParam servers: Array[String], @RequestParam(required = false, defaultValue = "") properties: Array[String]): CompletableFuture[Boolean] = {
+    Try {
+      Map(properties map { property =>
+        val splitProperty = property.split("=")
+        splitProperty(0) -> splitProperty(1)
+      }: _*)
+    } match {
+      case Success(propertiesMap) => kafkaService.existsTopic(topicName, servers, propertiesMap).toJava.toCompletableFuture
+      case Failure(exception) => throw new MethodArgumentTypeMismatchException(
+        properties,
+        Map.getClass,
+        "properties",
+        new MethodParameter(
+          classOf[KafkaController].getMethod("existsTopic", classOf[String], classOf[Array[String]], classOf[Array[String]]),
+          2
+        ),
+        exception
+      )
+    }
   }
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
@@ -29,14 +29,14 @@ import collection.JavaConversions._
 import scala.util.{Failure, Success, Try}
 
 trait KafkaService {
-  def doesKafkaTopicExist(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean]
+  def existsTopic(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean]
 }
 
 @Service
 class KafkaServiceImpl(val kafkaConfig: KafkaConfig) extends KafkaService {
   private val serviceLogger = LoggerFactory.getLogger(this.getClass)
 
-  override def doesKafkaTopicExist(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean] = {
+  override def existsTopic(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean] = {
     def closeAdminClient(adminClient: AdminClient): Unit = if (adminClient != null) adminClient.close()
 
     val properties = kafkaConfig.properties
@@ -59,7 +59,7 @@ class KafkaServiceImpl(val kafkaConfig: KafkaConfig) extends KafkaService {
           case _ =>
             closeAdminClient(adminClient)
             serviceLogger.error(s"Unexpected error occurred checking kafka topic = $kafkaTopicName, servers = $servers", exception)
-            throw new ApiException(GenericError("Could not establish connection."))
+            throw new ApiException(GenericError("Unexpected error occurred while connecting to kafka brokers"))
         }
       }
     }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.services
+
+import org.apache.kafka.clients.admin.{AdminClient, DescribeTopicsOptions}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import za.co.absa.hyperdrive.trigger.configuration.application.KafkaConfig
+import za.co.absa.hyperdrive.trigger.models.errors.{ApiException, GenericError}
+
+import java.util.Arrays.asList
+import scala.concurrent.{ExecutionContext, Future}
+import collection.JavaConversions._
+import scala.util.{Failure, Success, Try}
+
+trait KafkaService {
+  def doesKafkaTopicExist(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean]
+}
+
+@Service
+class KafkaServiceImpl(val kafkaConfig: KafkaConfig) extends KafkaService {
+  private val serviceLogger = LoggerFactory.getLogger(this.getClass)
+
+  override def doesKafkaTopicExist(kafkaTopicName: String, servers: Seq[String])(implicit ec: ExecutionContext): Future[Boolean] = {
+    def closeAdminClient(adminClient: AdminClient): Unit = if (adminClient != null) adminClient.close()
+
+    val properties = kafkaConfig.properties
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, servers.mkString(","))
+    var adminClient: AdminClient = null
+    Future {
+      Try {
+        adminClient = AdminClient.create(properties)
+        adminClient.describeTopics(
+          asList(kafkaTopicName), new DescribeTopicsOptions().timeoutMs(kafkaConfig.connectionTimeoutMillis)
+        ).all().get()
+      } match {
+        case Success(topics) =>
+          closeAdminClient(adminClient)
+          topics.exists(_._2.name() == kafkaTopicName)
+        case Failure(exception) => exception.getCause match {
+          case _: UnknownTopicOrPartitionException =>
+            closeAdminClient(adminClient)
+            false
+          case _ =>
+            closeAdminClient(adminClient)
+            serviceLogger.error(s"Unexpected error occurred checking kafka topic = $kafkaTopicName, servers = $servers", exception)
+            throw new ApiException(GenericError("Could not establish connection."))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/KafkaConfig.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/KafkaConfig.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.hyperdrive.trigger.configuration.application
 
-import org.springframework.boot.context.properties.bind.Name
+import org.springframework.boot.context.properties.bind.{DefaultValue, Name}
 import org.springframework.boot.context.properties.{ConfigurationProperties, ConstructorBinding}
 import org.springframework.validation.annotation.Validated
 
@@ -35,5 +35,8 @@ class KafkaConfig (
   val groupIdPrefix: String,
   @Name("poll.duration")
   @NotNull
-  val pollDuration: Long
+  val pollDuration: Long,
+  @DefaultValue(Array("120000"))
+  @Name("connectionTimeoutMillis")
+  val connectionTimeoutMillis: Int = 120000
 )

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
@@ -34,6 +34,7 @@ import scala.concurrent.Future
 class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
   private val kafkaPort = 12345
   private val kafkaUrl = s"localhost:${kafkaPort}"
+  private val kafkaProperties: Map[String, String] = Map.empty
   private val testKafkaConfig: KafkaConfig = TestKafkaConfig()
   private implicit val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = 12346)
 
@@ -43,7 +44,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
       createTopic(testTopic)
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
-      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl)))
+      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl), kafkaProperties))
 
       result shouldBe true
     }
@@ -54,7 +55,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
       val testTopic = "fakeTopic"
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
-      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl)))
+      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl), kafkaProperties))
 
       result shouldBe false
     }
@@ -68,7 +69,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
 
-      val result = the[ApiException] thrownBy await(underTest.existsTopic(testTopic, Seq(fakeKafkaUrl)))
+      val result = the[ApiException] thrownBy await(underTest.existsTopic(testTopic, Seq(fakeKafkaUrl), kafkaProperties))
 
       result.apiErrors should have size 1
       result.apiErrors.head shouldBe GenericError("Unexpected error occurred while connecting to kafka brokers")

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
@@ -1,0 +1,93 @@
+
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.api.rest.services
+
+import net.manub.embeddedkafka.EmbeddedKafka.withRunningKafka
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import za.co.absa.hyperdrive.trigger.TestUtils.await
+import za.co.absa.hyperdrive.trigger.configuration.application.{KafkaConfig, TestKafkaConfig}
+import za.co.absa.hyperdrive.trigger.models.errors.{ApiException, GenericError}
+
+import java.util.Arrays.asList
+import java.util.Properties
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
+  private val kafkaPort = 12345
+  private val kafkaUrl = s"localhost:${kafkaPort}"
+  private val testKafkaConfig: KafkaConfig = TestKafkaConfig()
+  private implicit val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = 12346)
+
+  "KafkaService.doesKafkaTopicExist" should "return true if topic exists" in {
+    withRunningKafka {
+      val testTopic = "testTopic"
+      createTopic(testTopic)
+
+      val underTest = new KafkaServiceImpl(testKafkaConfig)
+      val result = await(underTest.doesKafkaTopicExist(testTopic, Seq(kafkaUrl)))
+
+      result shouldBe true
+    }
+  }
+
+  it should "return false if topic does not exist" in {
+    withRunningKafka {
+      val testTopic = "fakeTopic"
+
+      val underTest = new KafkaServiceImpl(testKafkaConfig)
+      val result = await(underTest.doesKafkaTopicExist(testTopic, Seq(kafkaUrl)))
+
+      result shouldBe false
+    }
+  }
+
+  it should "should throw exception if connection could not be established" in {
+    withRunningKafka {
+      val testTopic = "testTopic"
+      val fakeKafkaUrl = "localhost:9999"
+      createTopic(testTopic)
+
+      val underTest = new KafkaServiceImpl(testKafkaConfig)
+
+      val result = the[ApiException] thrownBy await(underTest.doesKafkaTopicExist(testTopic, Seq(fakeKafkaUrl)))
+
+      result.apiErrors should have size 1
+      result.apiErrors.head shouldBe GenericError("Could not establish connection.")
+    }
+  }
+
+
+  private def createAdminClient(): AdminClient = {
+    val properties = new Properties()
+    properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl)
+    AdminClient.create(properties)
+  }
+
+  private def createTopic(topicName: String): Unit = {
+    val adminClient: AdminClient = createAdminClient()
+    val createTopicResponse = Future(
+      adminClient.createTopics(asList(new NewTopic(topicName, 1, 1))).all().get()
+    )
+    await(createTopicResponse)
+    adminClient.close()
+  }
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
@@ -37,13 +37,13 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
   private val testKafkaConfig: KafkaConfig = TestKafkaConfig()
   private implicit val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = 12346)
 
-  "KafkaService.doesKafkaTopicExist" should "return true if topic exists" in {
+  "KafkaService.existsTopic" should "return true if topic exists" in {
     withRunningKafka {
       val testTopic = "testTopic"
       createTopic(testTopic)
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
-      val result = await(underTest.doesKafkaTopicExist(testTopic, Seq(kafkaUrl)))
+      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl)))
 
       result shouldBe true
     }
@@ -54,7 +54,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
       val testTopic = "fakeTopic"
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
-      val result = await(underTest.doesKafkaTopicExist(testTopic, Seq(kafkaUrl)))
+      val result = await(underTest.existsTopic(testTopic, Seq(kafkaUrl)))
 
       result shouldBe false
     }
@@ -68,7 +68,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
 
       val underTest = new KafkaServiceImpl(testKafkaConfig)
 
-      val result = the[ApiException] thrownBy await(underTest.doesKafkaTopicExist(testTopic, Seq(fakeKafkaUrl)))
+      val result = the[ApiException] thrownBy await(underTest.existsTopic(testTopic, Seq(fakeKafkaUrl)))
 
       result.apiErrors should have size 1
       result.apiErrors.head shouldBe GenericError("Could not establish connection.")

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaServiceTest.scala
@@ -71,7 +71,7 @@ class KafkaServiceTest extends FlatSpec with MockitoSugar with Matchers with Bef
       val result = the[ApiException] thrownBy await(underTest.existsTopic(testTopic, Seq(fakeKafkaUrl)))
 
       result.apiErrors should have size 1
-      result.apiErrors.head shouldBe GenericError("Could not establish connection.")
+      result.apiErrors.head shouldBe GenericError("Unexpected error occurred while connecting to kafka brokers")
     }
   }
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestKafkaConfig.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestKafkaConfig.scala
@@ -24,6 +24,6 @@ object TestKafkaConfig {
     properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     properties.put("max.poll.records", "100")
-    new KafkaConfig(properties, "groupIdPrefix", 500)
+    new KafkaConfig(properties, "groupIdPrefix", 500, 10000)
   }
 }


### PR DESCRIPTION
Implements #523 

- Exposed new endpoint to check if kafka topic exist 
- Endpoint: GET /doesKafkaTopicExist?kafkaTopicName=<topic-name>&servers=<server1>,<server2>

New application property:
`kafkaSource.connectionTimeoutMillis`