### PR TITLE
#562: get dags to run query refactoring

### DIFF
--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/DagInstanceRepository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/DagInstanceRepository.scala
@@ -91,7 +91,6 @@ class DagInstanceRepositoryImpl @Inject()(val dbProvider: DatabaseProvider) exte
       dag
     }
 
-    dagsToRunQuery.result.statements.foreach(println)
     db.run(dagsToRunQuery.result)
   }
 

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/JobScheduler.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/JobScheduler.scala
@@ -112,7 +112,11 @@ class JobScheduler @Inject()(sensors: Sensors, executors: Executors, dagInstance
   }
 
   private def enqueueDags(assignedWorkflowIds: Seq[Long], emptySlotsSize: Int): Future[Unit] = {
-    dagInstanceRepository.getDagsToRun(runningDags.keys.map(_.dagId).toSeq, emptySlotsSize, assignedWorkflowIds).map {
+    dagInstanceRepository.getDagsToRun(
+      runningDags.keys.map(_.workflowId).toSeq.distinct,
+      emptySlotsSize,
+      assignedWorkflowIds
+    ).map {
       _.foreach { dag =>
         logger.debug(s"Deploying dag = ${dag.id}")
         runningDags.put(RunningDagsKey(dag.id, dag.workflowId), executors.executeDag(dag))

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/DagInstanceRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/DagInstanceRepositoryTest.scala
@@ -42,45 +42,45 @@ class DagInstanceRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
   }
 
   "dagInstanceRepository.getDagsToRun" should "return zero dag instances when db is empty" in {
-    val runningIds = Seq.empty[Long]
+    val runningWorkflowIds = Seq.empty[Long]
     val size = 10
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, Seq()))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, Seq()))
     result.isEmpty shouldBe true
   }
 
   "dagInstanceRepository.getDagsToRun" should "return one running dag for each workflow" in {
     createTestData()
-    val runningIds = Seq.empty[Long]
+    val runningWorkflowIds = Seq.empty[Long]
     val allWorkflowIds = TestData.workflows.map(_.id)
     val size = 10
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, allWorkflowIds))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, allWorkflowIds))
     result.size shouldBe 2
   }
 
   "dagInstanceRepository.getDagsToRun" should "filter out all dags" in {
     createTestData()
-    val runningIds = TestData.dagInstances.map(_.id)
+    val runningWorkflowIds = TestData.dagInstances.map(_.workflowId)
     val allWorkflowIds = TestData.workflows.map(_.id)
     val size = 10
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, allWorkflowIds))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, allWorkflowIds))
     result.size shouldBe 0
   }
 
   "dagInstanceRepository.getDagsToRun" should "filter out running dags" in {
     createTestData()
-    val runningIds = TestData.runningDagInstances.map(_.id)
+    val runningWorkflowIds = TestData.runningDagInstances.map(_.workflowId)
     val allWorkflowIds = TestData.workflows.map(_.id)
     val size = 10
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, allWorkflowIds))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, allWorkflowIds))
     result.foreach(_.status shouldBe DagInstanceStatuses.InQueue)
   }
 
   "dagInstanceRepository.getDagsToRun" should "return one running dag for each workflow with limited size" in {
     createTestData()
-    val runningIds = Seq.empty[Long]
+    val runningWorkflowIds = Seq.empty[Long]
     val allWorkflowIds = TestData.workflows.map(_.id)
     val size = 1
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, allWorkflowIds))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, allWorkflowIds))
     result.size shouldBe 1
   }
 
@@ -93,11 +93,11 @@ class DagInstanceRepositoryTest extends FlatSpec with Matchers with BeforeAndAft
     run(workflowTable.forceInsertAll(workflows))
     run(dagInstanceTable.forceInsertAll(dagInstances))
 
-    val runningIds = Seq.empty[Long]
+    val runningWorkflowIds = Seq.empty[Long]
     val assignedWorkflowIds = workflowIds.take(10)
     val size = 1000
 
-    val result = await(dagInstanceRepository.getDagsToRun(runningIds, size, assignedWorkflowIds))
+    val result = await(dagInstanceRepository.getDagsToRun(runningWorkflowIds, size, assignedWorkflowIds))
     result.size shouldBe 10
     result.map(_.workflowId) should contain theSameElementsAs assignedWorkflowIds
   }


### PR DESCRIPTION
Closes #562 

Generated query:
<img width="965" alt="Screenshot 2021-12-21 at 10 01 39" src="https://user-images.githubusercontent.com/18142017/146901873-edbad53e-f5cd-466c-8855-c544c9684ea4.png">

To copy:
```
select *
from (
    select min("id") as minDagInstanceId
    from "dag_instance"
    where (("status" in ('InQueue', 'Running')) and ("workflow_id" in (?, ?, ?))) and (not ("workflow_id" in (?, ?, ?)))
    group by "workflow_id" order by min("id") limit 3
) subQuery, "dag_instance" di
where di."id" = subQuery.minDagInstanceId;
```