### PR TITLE
Scala upgrade 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,9 +379,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <scalaVersion>${scala.compat.version}</scalaVersion>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <scalatest.version>3.0.5</scalatest.version>
         <h2database.version>2.0.206</h2database.version>
         <testcontainers.postgresql.version>1.15.3</testcontainers.postgresql.version>
-        <mockito.version>2.25.0</mockito.version>
+        <mockito.version>4.2.0</mockito.version>
         <cron-expression-descriptor.version>1.2</cron-expression-descriptor.version>
         <node.version>12.14.1</node.version>
         <npm.version>6.13.4</npm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <scalatest.version>3.0.5</scalatest.version>
         <h2database.version>2.0.206</h2database.version>
         <testcontainers.postgresql.version>1.15.3</testcontainers.postgresql.version>
-        <mockito.version>4.2.0</mockito.version>
+        <mockito.version>2.25.0</mockito.version>
         <cron-expression-descriptor.version>1.2</cron-expression-descriptor.version>
         <node.version>12.14.1</node.version>
         <npm.version>6.13.4</npm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <scala.compat.version>2.11</scala.compat.version>
+        <scala.compat.version>2.12</scala.compat.version>
         <spark.version>2.4.4</spark.version>
         <slick.version>3.3.3</slick.version>
         <tminglei.version>0.19.6</tminglei.version>
@@ -330,7 +330,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.embeddedkafka</groupId>
-            <artifactId>embedded-kafka_2.11</artifactId>
+            <artifactId>embedded-kafka_${scala.compat.version}</artifactId>
             <version>${embedded.kafka.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/eventProcessor/EventProcessor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/eventProcessor/EventProcessor.scala
@@ -32,7 +32,7 @@ class EventProcessor(eventRepository: EventRepository,
 
   def eventProcessor(triggeredBy: String)(events: Seq[Event], sensorId: Long)(implicit ec: ExecutionContext): Future[Boolean] = {
     val fut = processEvents(events, sensorId, triggeredBy)
-    logger.debug(s"Processing events. Sensor id: ${sensorId}. Events: ${events.map(_.id)}")
+    logger.debug(s"Processing events. Sensor id: $sensorId. Events: ${events.map(_.id)}")
     fut
   }
 
@@ -53,8 +53,9 @@ class EventProcessor(eventRepository: EventRepository,
           case None =>
             Future.successful(true)
         }
+      } else {
+        Future.successful(true)
       }
-      Future.successful(true)
     }
   }
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/WorkflowControllerTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/WorkflowControllerTest.scala
@@ -31,10 +31,11 @@ import za.co.absa.hyperdrive.trigger.configuration.application.TestGeneralConfig
 import za.co.absa.hyperdrive.trigger.models.errors.ApiException
 import za.co.absa.hyperdrive.trigger.models.{Project, Workflow, WorkflowImportExportWrapper}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class WorkflowControllerTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val workflowService = mock[WorkflowService]
   private val underTest = new WorkflowController(workflowService, TestGeneralConfig())
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/DagInstanceServiceTest.scala
@@ -23,10 +23,11 @@ import za.co.absa.hyperdrive.trigger.TestUtils.await
 import za.co.absa.hyperdrive.trigger.models.{ResolvedJobDefinition, ShellInstanceParameters, SparkInstanceParameters}
 import za.co.absa.hyperdrive.trigger.models.enums.{DagInstanceStatuses, JobStatuses, JobTypes}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class DagInstanceServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val jobTemplateService = mock[JobTemplateService]
   private val underTest = new DagInstanceServiceImpl(jobTemplateService)
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateServiceTest.scala
@@ -27,10 +27,11 @@ import za.co.absa.hyperdrive.trigger.models.errors.{ApiException, ValidationErro
 import za.co.absa.hyperdrive.trigger.models.search.{TableSearchRequest, TableSearchResponse}
 import za.co.absa.hyperdrive.trigger.persistance.JobTemplateRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class JobTemplateServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val jobTemplateRepository = mock[JobTemplateRepository]
   private val jobTemplateResolutionUtil = mock[JobTemplateResolutionService]
   private val jobTemplateValidationService = mock[JobTemplateValidationService]

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateValidationServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateValidationServiceTest.scala
@@ -24,10 +24,11 @@ import za.co.absa.hyperdrive.trigger.api.rest.services.JobTemplateFixture.Generi
 import za.co.absa.hyperdrive.trigger.models.errors.{ApiException, ValidationError}
 import za.co.absa.hyperdrive.trigger.persistance.JobTemplateRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class JobTemplateValidationServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val jobTemplateRepository = mock[JobTemplateRepository]
   private val underTest = new JobTemplateValidationServiceImpl(jobTemplateRepository)
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/NotificationRuleServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/NotificationRuleServiceTest.scala
@@ -27,10 +27,11 @@ import za.co.absa.hyperdrive.trigger.models.{NotificationRule, Workflow}
 import za.co.absa.hyperdrive.trigger.persistance.NotificationRuleRepository
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class NotificationRuleServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter with OptionValues {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val notificationRuleRepository = mock[NotificationRuleRepository]
   private val notificationRuleValidationService = mock[NotificationRuleValidationService]
   private val userName = "some-user"

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/NotificationRuleValidationServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/NotificationRuleValidationServiceTest.scala
@@ -18,17 +18,18 @@ package za.co.absa.hyperdrive.trigger.api.rest.services
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
 import za.co.absa.hyperdrive.trigger.TestUtils.await
 import za.co.absa.hyperdrive.trigger.models.NotificationRule
 import za.co.absa.hyperdrive.trigger.models.enums.DagInstanceStatuses
 import za.co.absa.hyperdrive.trigger.models.errors.{ApiException, ValidationError}
 import za.co.absa.hyperdrive.trigger.persistance.WorkflowRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class NotificationRuleValidationServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val workflowRepository = mock[WorkflowRepository]
   private val underTest = new NotificationRuleValidationServiceImpl(workflowRepository)
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowServiceTest.scala
@@ -29,10 +29,11 @@ import za.co.absa.hyperdrive.trigger.models.errors.ApiErrorTypes.{BulkOperationE
 import za.co.absa.hyperdrive.trigger.models.errors.{ApiError, ApiException, DatabaseError, ValidationError}
 import za.co.absa.hyperdrive.trigger.persistance.{DagInstanceRepository, WorkflowRepository}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkflowServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val workflowRepository = mock[WorkflowRepository]
   private val dagInstanceRepository = mock[DagInstanceRepository]
   private val dagInstanceService = mock[DagInstanceService]

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowValidationServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/WorkflowValidationServiceTest.scala
@@ -26,10 +26,11 @@ import za.co.absa.hyperdrive.trigger.models.errors.{ApiError, ApiException, Bulk
 import za.co.absa.hyperdrive.trigger.persistance.WorkflowRepository
 
 import scala.collection.immutable.SortedMap
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkflowValidationServiceTest extends AsyncFlatSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val workflowRepository = mock[WorkflowRepository]
   private val jobTemplateService = mock[JobTemplateService]
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
@@ -28,10 +28,11 @@ import za.co.absa.hyperdrive.trigger.models._
 import za.co.absa.hyperdrive.trigger.models.enums.SchedulerInstanceStatuses
 import za.co.absa.hyperdrive.trigger.persistance.SchedulerInstanceRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class SchedulerInstanceServiceTest extends AsyncFlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val schedulerInstanceRepository = mock[SchedulerInstanceRepository]
   private val underTest = new SchedulerInstanceServiceImpl(schedulerInstanceRepository)
 

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/WorkflowBalancerTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/WorkflowBalancerTest.scala
@@ -27,10 +27,11 @@ import za.co.absa.hyperdrive.trigger.configuration.application.TestSchedulerConf
 import za.co.absa.hyperdrive.trigger.models._
 import za.co.absa.hyperdrive.trigger.models.enums.SchedulerInstanceStatuses
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkflowBalancerTest extends AsyncFlatSpec with MockitoSugar with Matchers with BeforeAndAfter {
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val schedulerInstanceService = mock[SchedulerInstanceService]
   private val workflowBalancingService = mock[WorkflowBalancingService]
   private val schedulerConfig = TestSchedulerConfig()


### PR DESCRIPTION
Upgrade to scala 2.12
Implements #582 
Changes:
- Removed `scalaVersion` from `scala-maven-plugin` (Recommended in docs)
- Test updated: Instead of using execution context from AsyncFlatSpec, overrided with global execution context

Tested locally with yarn deployment and shell execution + notifications and templates