### PR TITLE
602: Workflows are shown to be unselected when moving across pages

### DIFF
--- a/ui/src/app/components/workflows/workflows-home/workflows-home.component.ts
+++ b/ui/src/app/components/workflows/workflows-home/workflows-home.component.ts
@@ -213,6 +213,7 @@ export class WorkflowsHomeComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   refresh() {
+    this.selected = [];
     const searchRequestModel: TableSearchRequestModel = {
       from: this.pageFrom,
       size: this.pageSize,


### PR DESCRIPTION
Implements #602

As discussed: If not possible to fix it, disable selection on multiple pages. 