### PR TITLE
Feature/700 skip dag instance 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ The Hadoop configuration directory needs to be added as the environment variable
 - To add the Hadoop configuration directory to the application classpath, 
 in the file `<tomcat-base>/conf/catalina.properties`, append to the key `shared.loader` the hadoop conf dir, e.g. `shared.loader="/opt/hadoop"`.
 
+### Symbolic links on user-defined files
+With [Feature #700: Skip dag instance creation if no new message is available in Kafka](https://github.com/AbsaOSS/hyperdrive-trigger/issues/700),
+the application needs to access files that are defined in job templates for Hyperdrive jobs. Especially, it will need 
+to access any files specified under `reader.option.kafka` to configure Kafka consumers, e.g. keystore, truststore
+and keytabs under the same path as the Spark job would see them.
+
+For example, a (resolved) job template may include
+- Additional files: `/etc/config/keystore.jks#keystore.jks`
+- App arguments: `reader.option.kafka.ssl.keystore.location=keystore.jks`
+
+In this case, obviously `/etc/config/keystore.jks` needs to exist to submit the job, but additionally, 
+`<tomcat-root-directory>/keystore.jks` needs to exist such that the web application can access the file under the same path
+as the Spark job would, in order to be able to create a Kafka consumer using the same configuration as the Spark job. This
+may obviously be achieved using symbolic links.
+
+For access to HDFS, `spark.yarn.keytab` and `spark.yarn.principal` from the application properties are used for authentication.
+No symbolic links are required.
+
 ## Embedded Tomcat
 
 For development purposes, hyperdrive-trigger can be executed as an application with an embedded tomcat. Please check out branch **feature/embedded-tomcat-2** to use it.

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/CheckpointService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/CheckpointService.scala
@@ -101,7 +101,6 @@ class CheckpointServiceImpl @Inject() (hdfsService: HdfsService) extends Checkpo
    *  and org.apache.spark.sql.kafka010.JsonUtils
    *  for details on the assumed format
    */
-
   private def parseKafkaOffsetStream(lines: Iterator[String]): TopicPartitionOffsets = {
     val SERIALIZED_VOID_OFFSET = "-"
     def parseOffset(value: String): Option[TopicPartitionOffsets] = value match {

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/HyperdriveOffsetComparisonService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/HyperdriveOffsetComparisonService.scala
@@ -96,8 +96,10 @@ class HyperdriveOffsetComparisonServiceImpl @Inject() (sparkConfig: SparkConfig,
                   if (allConsumed) {
                     logger.info(s"All offsets consumed for topic ${kafkaParametersOpt.get._1}. Skipping job instance")
                   } else {
-                    logger.debug(s"Some offsets haven't been consumed yet for topic ${kafkaParametersOpt.get._1}. Kafka offsets: ${kafkaEndOffsets}, " +
-                      s"Checkpoint offsets: ${checkpointOffsets}")
+                    logger.debug(
+                      s"Some offsets haven't been consumed yet for topic ${kafkaParametersOpt.get._1}. Kafka offsets: ${kafkaEndOffsets}, " +
+                        s"Checkpoint offsets: ${checkpointOffsets}"
+                    )
                   }
                   !allConsumed
                 case _ => true

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/HyperdriveOffsetComparisonService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/HyperdriveOffsetComparisonService.scala
@@ -93,7 +93,12 @@ class HyperdriveOffsetComparisonServiceImpl @Inject() (sparkConfig: SparkConfig,
               getCheckpointOffsets(jobParameters, kafkaParametersOpt).map {
                 case Some(checkpointOffsets) =>
                   val allConsumed = offsetsConsumed(checkpointOffsets, kafkaEndOffsets)
-                  logger.info(s"All offsets consumed for topic ${kafkaParametersOpt.get._1}. Skipping job instance")
+                  if (allConsumed) {
+                    logger.info(s"All offsets consumed for topic ${kafkaParametersOpt.get._1}. Skipping job instance")
+                  } else {
+                    logger.debug(s"Some offsets haven't been consumed yet for topic ${kafkaParametersOpt.get._1}. Kafka offsets: ${kafkaEndOffsets}, " +
+                      s"Checkpoint offsets: ${checkpointOffsets}")
+                  }
                   !allConsumed
                 case _ => true
               }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateResolutionService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/JobTemplateResolutionService.scala
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Service
 import za.co.absa.hyperdrive.trigger.configuration.application.JobDefinitionConfig.{SparkExtraJavaOptions, SparkTags}
 import za.co.absa.hyperdrive.trigger.models._
 import za.co.absa.hyperdrive.trigger.api.rest.utils.Extensions.{SparkConfigList, SparkConfigMap}
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes
+import za.co.absa.hyperdrive.trigger.models.enums.JobTypes.JobType
 
 import scala.util.{Failure, Success, Try}
 
@@ -99,6 +101,7 @@ class JobTemplateResolutionServiceImpl extends JobTemplateResolutionService {
     templateParams: SparkTemplateParameters
   ): SparkInstanceParameters =
     SparkInstanceParameters(
+      jobType = mergeSparkJobType(definitionParams.jobType, templateParams.jobType),
       jobJar = mergeOptionString(definitionParams.jobJar, templateParams.jobJar),
       mainClass = mergeOptionString(definitionParams.mainClass, templateParams.mainClass),
       appArguments = mergeLists(definitionParams.appArguments, templateParams.appArguments),
@@ -110,6 +113,14 @@ class JobTemplateResolutionServiceImpl extends JobTemplateResolutionService {
         mergeSortedMapEntries
       ).toAdditionalSparkConfigList
     )
+
+  private def mergeSparkJobType(definitionJobType: JobType, templateJobType: JobType) = {
+    if (definitionJobType == templateJobType) {
+      definitionJobType
+    } else {
+      JobTypes.Spark
+    }
+  }
 
   private def mergeShellParameters(
     definitionParams: ShellDefinitionParameters,

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/api/rest/services/KafkaService.scala
@@ -36,6 +36,7 @@ trait KafkaService {
 @Service
 class KafkaServiceImpl @Inject() (generalConfig: GeneralConfig) extends KafkaService {
   private val logger = LoggerFactory.getLogger(this.getClass)
+  private val consumerUuid = randomUUID().toString
   private val kafkaConsumersCache = new ConcurrentLruCache[(Properties, Long), KafkaConsumer[String, String]](
     generalConfig.kafkaConsumersCacheSize,
     createKafkaConsumer
@@ -58,7 +59,7 @@ class KafkaServiceImpl @Inject() (generalConfig: GeneralConfig) extends KafkaSer
   }
 
   private def getOffsets(topic: String, properties: Properties, offsetFn: OffsetFunction): Map[Int, Long] = {
-    val groupId = s"hyperdrive-trigger-kafkaService-${randomUUID().toString}"
+    val groupId = s"hyperdrive-trigger-kafkaService-$consumerUuid"
     properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
     val consumer = kafkaConsumersCache.get((properties, Thread.currentThread().getId))
     val partitionInfo = Option(consumer.partitionsFor(topic)).map(_.asScala).getOrElse(Seq())

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/SchedulerConfig.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/SchedulerConfig.scala
@@ -57,5 +57,7 @@ class Sensors(
 class Executors(
   @NotNull
   @Name("thread.pool.size")
-  val threadPoolSize: Int
+  val threadPoolSize: Int,
+  @DefaultValue(Array("true"))
+  val enableHyperdriveExecutor: Boolean
 )

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/models/enums/JobStatuses.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/models/enums/JobStatuses.scala
@@ -37,6 +37,7 @@ object JobStatuses {
   case object InvalidExecutor extends JobStatus("InvalidExecutor", true, true, false)
   case object FailedPreviousJob extends JobStatus("FailedPreviousJob", true, true, false)
   case object Skipped extends JobStatus("Skipped", true, false, false)
+  case object NoData extends JobStatus("No Data", true, false, false)
 
   val statuses: Set[JobStatus] = Set(
     InQueue,
@@ -49,7 +50,8 @@ object JobStatuses {
     SubmissionTimeout,
     InvalidExecutor,
     FailedPreviousJob,
-    Skipped
+    Skipped,
+    NoData
   )
   val finalStatuses: Set[JobStatus] = statuses.filter(!_.isFinalStatus)
   val nonFinalStatuses: Set[JobStatus] = statuses.filter(_.isFinalStatus)

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
@@ -82,7 +82,8 @@ class Executors @Inject() (
           case _ =>
         }
         fut
-      case jobInstances if jobInstances.forall(ji => ji.jobStatus.isFinalStatus && ji.jobStatus == JobStatuses.NoData) =>
+      case jobInstances
+          if jobInstances.forall(ji => ji.jobStatus.isFinalStatus && ji.jobStatus == JobStatuses.NoData) =>
         val updatedDagInstance =
           dagInstance.copy(status = DagInstanceStatuses.Skipped, finished = Option(LocalDateTime.now()))
         val fut = for {

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
@@ -125,7 +125,7 @@ class Executors @Inject() (
   private def useHyperExecutor(parameters: SparkInstanceParameters) = {
     schedulerConfig.executors.enableHyperdriveExecutor &&
     parameters.jobType == JobTypes.Hyperdrive &&
-    parameters.appArguments.contains("useHyperdriveExecutor")
+    parameters.appArguments.contains("useHyperdriveExecutor=true")
   }
 
   private def updateJob(jobInstance: JobInstance): Future[Unit] = {

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
@@ -22,7 +22,13 @@ import za.co.absa.hyperdrive.trigger.models.{DagInstance, JobInstance, ShellInst
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.InvalidExecutor
 import za.co.absa.hyperdrive.trigger.models.enums.{DagInstanceStatuses, JobStatuses, JobTypes}
 import za.co.absa.hyperdrive.trigger.persistance.{DagInstanceRepository, JobInstanceRepository}
-import za.co.absa.hyperdrive.trigger.scheduler.executors.spark.{HyperdriveExecutor, SparkClusterService, SparkEmrClusterServiceImpl, SparkExecutor, SparkYarnClusterServiceImpl}
+import za.co.absa.hyperdrive.trigger.scheduler.executors.spark.{
+  HyperdriveExecutor,
+  SparkClusterService,
+  SparkEmrClusterServiceImpl,
+  SparkExecutor,
+  SparkYarnClusterServiceImpl
+}
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanFactory
 import za.co.absa.hyperdrive.trigger.scheduler.executors.shell.ShellExecutor
@@ -42,7 +48,7 @@ class Executors @Inject() (
   beanFactory: BeanFactory,
   implicit val sparkConfig: SparkConfig,
   schedulerConfig: SchedulerConfig,
-  hyperdriveOffsetComparisonService: HyperdriveOffsetComparisonService,
+  hyperdriveOffsetComparisonService: HyperdriveOffsetComparisonService
 ) {
   private val logger = LoggerFactory.getLogger(this.getClass)
   private implicit val executionContext: ExecutionContextExecutor =
@@ -95,7 +101,9 @@ class Executors @Inject() (
           jobInstance match {
             case Some(ji) =>
               ji.jobParameters match {
-                case hyperdrive: SparkInstanceParameters if hyperdrive.jobType == JobTypes.Hyperdrive => HyperdriveExecutor.execute(ji, hyperdrive, updateJob, sparkClusterService, hyperdriveOffsetComparisonService)
+                case hyperdrive: SparkInstanceParameters if hyperdrive.jobType == JobTypes.Hyperdrive =>
+                  HyperdriveExecutor
+                    .execute(ji, hyperdrive, updateJob, sparkClusterService, hyperdriveOffsetComparisonService)
                 case spark: SparkInstanceParameters => SparkExecutor.execute(ji, spark, updateJob, sparkClusterService)
                 case shell: ShellInstanceParameters => ShellExecutor.execute(ji, shell, updateJob)
                 case _                              => updateJob(ji.copy(jobStatus = InvalidExecutor))

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
@@ -38,9 +38,9 @@ object HyperdriveExecutor {
 
   private def submitJob(sparkClusterService: SparkClusterService, offsetComparisonService: HyperdriveOffsetComparisonService, jobInstance: JobInstance, jobParameters: SparkInstanceParameters, updateJob: JobInstance => Future[Unit])(implicit executionContext: ExecutionContext) = {
     for {
-      newJobRequired <- offsetComparisonService.isNewJobInstanceRequired(jobInstance.jobParameters)
-      _ <- sparkClusterService.submitJob(jobInstance, jobParameters, updateJob) if newJobRequired
-      _ <- updateJob(jobInstance.copy(jobStatus = JobStatuses.NoData)) if !newJobRequired
+      newJobRequired <- offsetComparisonService.isNewJobInstanceRequired(jobParameters)
+      _ <- if (newJobRequired) sparkClusterService.submitJob(jobInstance, jobParameters, updateJob)
+      else updateJob(jobInstance.copy(jobStatus = JobStatuses.NoData))
     } yield ()
   }
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
@@ -19,7 +19,6 @@ import za.co.absa.hyperdrive.trigger.api.rest.services.HyperdriveOffsetCompariso
 import za.co.absa.hyperdrive.trigger.configuration.application.SparkConfig
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses
 import za.co.absa.hyperdrive.trigger.models.{JobInstance, SparkInstanceParameters}
-import za.co.absa.hyperdrive.trigger.scheduler.executors.spark.HyperdriveExecutor.submitJob
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
@@ -15,6 +15,7 @@
 
 package za.co.absa.hyperdrive.trigger.scheduler.executors.spark
 
+import org.slf4j.LoggerFactory
 import za.co.absa.hyperdrive.trigger.api.rest.services.HyperdriveOffsetComparisonService
 import za.co.absa.hyperdrive.trigger.configuration.application.SparkConfig
 import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses
@@ -23,6 +24,8 @@ import za.co.absa.hyperdrive.trigger.models.{JobInstance, SparkInstanceParameter
 import scala.concurrent.{ExecutionContext, Future}
 
 object HyperdriveExecutor {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
   def execute(
     jobInstance: JobInstance,
     jobParameters: SparkInstanceParameters,
@@ -42,6 +45,7 @@ object HyperdriveExecutor {
                         jobParameters: SparkInstanceParameters,
                         updateJob: JobInstance => Future[Unit]
   )(implicit executionContext: ExecutionContext) = {
+    logger.debug("Using HyperdriveExecutor")
     for {
       newJobRequired <- offsetComparisonService.isNewJobInstanceRequired(jobParameters)
       _ <-

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutor.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.scheduler.executors.spark
+
+import za.co.absa.hyperdrive.trigger.api.rest.services.HyperdriveOffsetComparisonService
+import za.co.absa.hyperdrive.trigger.configuration.application.SparkConfig
+import za.co.absa.hyperdrive.trigger.models.{JobInstance, SparkInstanceParameters}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object HyperdriveExecutor {
+  def execute(
+    jobInstance: JobInstance,
+    jobParameters: SparkInstanceParameters,
+    updateJob: JobInstance => Future[Unit],
+    sparkClusterService: SparkClusterService,
+    offsetComparisonService: HyperdriveOffsetComparisonService
+  )(implicit executionContext: ExecutionContext, sparkConfig: SparkConfig): Future[Unit] =
+    jobInstance.executorJobId match {
+      case None                => submitJob(sparkClusterService, offsetComparisonService, jobInstance, jobParameters, updateJob)
+      case Some(executorJobId) => SparkExecutor.updateJobStatus(executorJobId, jobInstance, updateJob, sparkClusterService)
+    }
+
+  private def submitJob(sparkClusterService: SparkClusterService, offsetComparisonService: HyperdriveOffsetComparisonService, jobInstance: JobInstance, jobParameters: SparkInstanceParameters, updateJob: JobInstance => Future[Unit]) = {
+    offsetComparisonService.isNewJobInstanceRequired()
+    sparkClusterService.submitJob(jobInstance, jobParameters, updateJob)
+  }
+}

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/SparkExecutor.scala
@@ -37,7 +37,7 @@ object SparkExecutor {
       case Some(executorJobId) => updateJobStatus(executorJobId, jobInstance, updateJob, sparkClusterService)
     }
 
-  private def updateJobStatus(
+  private[spark] def updateJobStatus(
     executorJobId: String,
     jobInstance: JobInstance,
     updateJob: JobInstance => Future[Unit],

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/CheckpointServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/services/CheckpointServiceTest.scala
@@ -72,9 +72,9 @@ class CheckpointServiceTest extends FlatSpec with Matchers with BeforeAndAfter w
 
     result.size shouldBe 2
     result.head._1 shouldBe "my.topic"
-    result.head._2 should contain theSameElementsAs Map("2" -> 2021, "1" -> 1021, "3" -> 3021, "0" -> 21)
+    result.head._2 should contain theSameElementsAs Map(2 -> 2021L, 1 -> 1021L, 3 -> 3021L, 0 -> 21L)
     result.toSeq(1)._1 shouldBe "my.other.topic"
-    result.toSeq(1)._2 should contain theSameElementsAs Map("0" -> 0)
+    result.toSeq(1)._2 should contain theSameElementsAs Map(0 -> 0L)
   }
 
   "getLatestOffsetFile" should "get the latest offset file, and it is committed" in {

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/api/rest/utils/JobTemplateResolutionServiceTest.scala
@@ -282,7 +282,7 @@ class JobTemplateResolutionServiceTest extends FlatSpec with Matchers {
     )
 
     // then
-    templateDefined.head.jobParameters.jobType shouldBe JobTypes.Spark
+    templateDefined.head.jobParameters.jobType shouldBe JobTypes.Hyperdrive
     templateDefined.head.jobParameters
       .asInstanceOf[SparkInstanceParameters]
       .jobJar shouldBe sparkTemplateParametersDefined.jobJar
@@ -302,7 +302,7 @@ class JobTemplateResolutionServiceTest extends FlatSpec with Matchers {
       .asInstanceOf[SparkInstanceParameters]
       .additionalSparkConfig should contain theSameElementsAs sparkTemplateParametersDefined.additionalSparkConfig
 
-    bothScriptsDefined.head.jobParameters.jobType shouldBe JobTypes.Spark
+    bothScriptsDefined.head.jobParameters.jobType shouldBe JobTypes.Hyperdrive
     bothScriptsDefined.head.jobParameters
       .asInstanceOf[SparkInstanceParameters]
       .jobJar shouldBe sparkTemplateParametersDefined.jobJar

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestSchedulerConfig.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestSchedulerConfig.scala
@@ -33,6 +33,6 @@ object TestSchedulerConfig {
       autostart,
       lagThreshold,
       new Sensors(sensorsThreadPoolSize, sensorsChangedSensorsChunkQuerySize),
-      new Executors(executorsThreadPoolSize)
+      new Executors(executorsThreadPoolSize, true)
     )
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutorTest.scala
@@ -1,0 +1,101 @@
+
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.trigger.scheduler.executors.spark
+
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{never, reset, verify, when}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
+import za.co.absa.hyperdrive.trigger.api.rest.services.HyperdriveOffsetComparisonService
+import za.co.absa.hyperdrive.trigger.configuration.application.{DefaultTestSparkConfig, SparkConfig}
+import za.co.absa.hyperdrive.trigger.models.enums.JobStatuses.InQueue
+import za.co.absa.hyperdrive.trigger.models.enums.{JobStatuses, JobTypes}
+import za.co.absa.hyperdrive.trigger.models.{JobInstance, SparkInstanceParameters}
+
+import java.time.LocalDateTime
+import scala.concurrent.Future
+
+class HyperdriveExecutorTest extends AsyncFlatSpec with MockitoSugar with BeforeAndAfter with Matchers {
+  private val offsetComparisonServiceMock = mock[HyperdriveOffsetComparisonService]
+  private val sparkClusterServiceMock = mock[SparkClusterService]
+  private val updateJobStub: JobInstance => Future[Unit] = mock[JobInstance => Future[Unit]]
+
+  before {
+    reset(offsetComparisonServiceMock)
+    reset(sparkClusterServiceMock)
+    reset(updateJobStub)
+  }
+
+  it should "submit a job if it is required" in {
+    val jobInstance = getJobInstance
+    val jobInstanceParameters = jobInstance.jobParameters.asInstanceOf[SparkInstanceParameters]
+
+    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future{true})
+    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future {(): Unit})
+    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future {(): Unit})
+
+    implicit val sparkConfig: SparkConfig = DefaultTestSparkConfig().yarn
+    val resultFut = HyperdriveExecutor.execute(jobInstance, jobInstanceParameters, updateJobStub, sparkClusterServiceMock, offsetComparisonServiceMock)
+
+    resultFut.map { _ =>
+      verify(sparkClusterServiceMock).submitJob(any(), any(), any())
+      verify(updateJobStub, never()).apply(any())
+      succeed
+    }
+  }
+
+  it should "not submit a job if it is not required" in {
+    val jobInstance = getJobInstance
+    val jobInstanceParameters = jobInstance.jobParameters.asInstanceOf[SparkInstanceParameters]
+
+    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future{false})
+    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future {(): Unit})
+    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future {(): Unit})
+
+    implicit val sparkConfig: SparkConfig = DefaultTestSparkConfig().yarn
+    val resultFut = HyperdriveExecutor.execute(jobInstance, jobInstanceParameters, updateJobStub, sparkClusterServiceMock, offsetComparisonServiceMock)
+
+    resultFut.map { _ =>
+      verify(sparkClusterServiceMock, never()).submitJob(any(), any(), any())
+      val jiCaptor: ArgumentCaptor[JobInstance] = ArgumentCaptor.forClass(classOf[JobInstance])
+      verify(updateJobStub).apply(jiCaptor.capture())
+      jiCaptor.getValue.jobStatus shouldBe JobStatuses.NoData
+    }
+  }
+
+  private def getJobInstance = {
+    val jobInstanceParameters = SparkInstanceParameters(
+      jobType = JobTypes.Hyperdrive,
+      jobJar = "job.jar",
+      mainClass = "mainClass",
+      appArguments = List()
+    )
+    JobInstance(
+      jobName = "jobName",
+      jobParameters = jobInstanceParameters,
+      jobStatus = InQueue,
+      executorJobId = None,
+      applicationId = None,
+      stepId = None,
+      created = LocalDateTime.now(),
+      updated = None,
+      order = 0,
+      dagInstanceId = 0
+    )
+  }
+}

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutorTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/spark/HyperdriveExecutorTest.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 ABSA Group Limited
  *
@@ -45,12 +44,17 @@ class HyperdriveExecutorTest extends AsyncFlatSpec with MockitoSugar with Before
     val jobInstance = getJobInstance
     val jobInstanceParameters = jobInstance.jobParameters.asInstanceOf[SparkInstanceParameters]
 
-    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future{true})
-    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future {(): Unit})
-    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future {(): Unit})
+    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future { true })
+    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future { (): Unit })
+    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future { (): Unit })
 
     implicit val sparkConfig: SparkConfig = DefaultTestSparkConfig().yarn
-    val resultFut = HyperdriveExecutor.execute(jobInstance, jobInstanceParameters, updateJobStub, sparkClusterServiceMock, offsetComparisonServiceMock)
+    val resultFut = HyperdriveExecutor.execute(jobInstance,
+                                               jobInstanceParameters,
+                                               updateJobStub,
+                                               sparkClusterServiceMock,
+                                               offsetComparisonServiceMock
+    )
 
     resultFut.map { _ =>
       verify(sparkClusterServiceMock).submitJob(any(), any(), any())
@@ -63,12 +67,17 @@ class HyperdriveExecutorTest extends AsyncFlatSpec with MockitoSugar with Before
     val jobInstance = getJobInstance
     val jobInstanceParameters = jobInstance.jobParameters.asInstanceOf[SparkInstanceParameters]
 
-    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future{false})
-    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future {(): Unit})
-    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future {(): Unit})
+    when(offsetComparisonServiceMock.isNewJobInstanceRequired(any())(any())).thenReturn(Future { false })
+    when(sparkClusterServiceMock.submitJob(any(), any(), any())).thenReturn(Future { (): Unit })
+    when(updateJobStub.apply(any[JobInstance])).thenReturn(Future { (): Unit })
 
     implicit val sparkConfig: SparkConfig = DefaultTestSparkConfig().yarn
-    val resultFut = HyperdriveExecutor.execute(jobInstance, jobInstanceParameters, updateJobStub, sparkClusterServiceMock, offsetComparisonServiceMock)
+    val resultFut = HyperdriveExecutor.execute(jobInstance,
+                                               jobInstanceParameters,
+                                               updateJobStub,
+                                               sparkClusterServiceMock,
+                                               offsetComparisonServiceMock
+    )
 
     resultFut.map { _ =>
       verify(sparkClusterServiceMock, never()).submitJob(any(), any(), any())

--- a/ui/src/app/components/runs/run-detail/run-detail.component.html
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.html
@@ -45,7 +45,7 @@
         <clr-icon *ngSwitchCase="jobStatuses.FAILED" shape="error-standard" class="is-solid" style="color: red"></clr-icon>
         <clr-icon *ngSwitchCase="jobStatuses.SKIPPED" shape="fast-forward" class="is-solid" style="color: grey"></clr-icon>
         <clr-icon *ngSwitchCase="jobStatuses.SUBMISSION_TIMEOUT" shape="clock" class="has-badge is-solid" style="color: orangered"></clr-icon>
-        <clr-icon *ngSwitchCase="jobStatuses.NO_DATA" shape="exclamation-circle" class="is-solid" style="color: orangered"></clr-icon>
+        <clr-icon *ngSwitchCase="jobStatuses.NO_DATA" shape="exclamation-triangle" class="is-solid" style="color: grey"></clr-icon>
         <clr-icon *ngSwitchDefault shape="help" class="is-solid" style="color: darkgoldenrod"></clr-icon>
         {{jobInstance.jobStatus.name}}
       </clr-dg-cell>

--- a/ui/src/app/components/runs/run-detail/run-detail.component.html
+++ b/ui/src/app/components/runs/run-detail/run-detail.component.html
@@ -45,6 +45,7 @@
         <clr-icon *ngSwitchCase="jobStatuses.FAILED" shape="error-standard" class="is-solid" style="color: red"></clr-icon>
         <clr-icon *ngSwitchCase="jobStatuses.SKIPPED" shape="fast-forward" class="is-solid" style="color: grey"></clr-icon>
         <clr-icon *ngSwitchCase="jobStatuses.SUBMISSION_TIMEOUT" shape="clock" class="has-badge is-solid" style="color: orangered"></clr-icon>
+        <clr-icon *ngSwitchCase="jobStatuses.NO_DATA" shape="exclamation-circle" class="is-solid" style="color: orangered"></clr-icon>
         <clr-icon *ngSwitchDefault shape="help" class="is-solid" style="color: darkgoldenrod"></clr-icon>
         {{jobInstance.jobStatus.name}}
       </clr-dg-cell>

--- a/ui/src/app/models/enums/jobStatuses.constants.ts
+++ b/ui/src/app/models/enums/jobStatuses.constants.ts
@@ -21,4 +21,5 @@ export const jobStatuses = {
   FAILED: 'Failed',
   SKIPPED: 'Skipped',
   SUBMISSION_TIMEOUT: 'Submission timeout',
+  NO_DATA: 'No Data',
 };


### PR DESCRIPTION
Closes #700 

Sets Dag instance status to Skipped if all job instances have status NoData (or if there are zero job instances).


**Added a property for testing**

`executors.enable.hyperdrive.executor` (optional, default true). If set to false, HyperdriveExecutor will not be used and instead, the SparkExecutor will be used for all workflows.

On top of enabling the HyperdriveExecutor globally, jobs also need to opt-in by specifying the following app argument:
`useHyperdriveExecutor=true`

Both items are only intended during a testing period, after which the logic for both things should be removed.

**Symbolic links on tomcat**
See section "Symbolic links on user-defined files" in the README for when and why to add symbolic links in the tomcat home folder to keytab and keystores.