### PR TITLE
#703 - Recognize dead scheduler instances without relying on synchronized clocks

### DIFF
--- a/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepository.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepository.scala
@@ -21,6 +21,7 @@ import za.co.absa.hyperdrive.trigger.models.SchedulerInstance
 import za.co.absa.hyperdrive.trigger.models.enums.SchedulerInstanceStatuses
 import za.co.absa.hyperdrive.trigger.models.enums.SchedulerInstanceStatuses.SchedulerInstanceStatus
 
+import java.sql.Timestamp
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -34,6 +35,8 @@ trait SchedulerInstanceRepository extends Repository {
   ): Future[Int]
 
   def getAllInstances()(implicit ec: ExecutionContext): Future[Seq[SchedulerInstance]]
+
+  def getCurrentDateTime()(implicit ec: ExecutionContext): Future[LocalDateTime]
 }
 
 @stereotype.Repository
@@ -76,4 +79,8 @@ class SchedulerInstanceRepositoryImpl @Inject() (val dbProvider: DatabaseProvide
   override def getAllInstances()(implicit ec: ExecutionContext): Future[Seq[SchedulerInstance]] = db.run {
     schedulerInstanceTable.result.withErrorHandling()
   }
+
+  override def getCurrentDateTime()(implicit ec: ExecutionContext): Future[LocalDateTime] =
+    db.run(sql"SELECT now()::timestamp".as[Timestamp]).map(_.head.toLocalDateTime)
+
 }

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceService.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceService.scala
@@ -17,7 +17,7 @@ package za.co.absa.hyperdrive.trigger.scheduler.cluster
 
 import org.slf4j.LoggerFactory
 
-import java.time.{Duration, LocalDateTime}
+import java.time.Duration
 import javax.inject.Inject
 import org.springframework.stereotype.Service
 import za.co.absa.hyperdrive.trigger.models.SchedulerInstance
@@ -45,8 +45,8 @@ class SchedulerInstanceServiceImpl @Inject() (schedulerInstanceRepository: Sched
   override def updateSchedulerStatus(instanceId: Long, lagThreshold: Duration)(
     implicit ec: ExecutionContext
   ): Future[Seq[SchedulerInstance]] = {
-    val currentHeartbeat = LocalDateTime.now()
     for {
+      currentHeartbeat <- schedulerInstanceRepository.getCurrentDateTime()
       updatedCount <- schedulerInstanceRepository.updateHeartbeat(instanceId, currentHeartbeat)
       _ <-
         if (updatedCount == 0) {

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
@@ -97,7 +97,7 @@ class SchedulerInstanceRepositoryTest
     val expectedBefore = LocalDateTime.now()
     val result = await(schedulerInstanceRepository.getCurrentDateTime())
     val expectedAfter = LocalDateTime.now()
-    result isAfter expectedBefore
-    result isBefore expectedAfter
+    (result isAfter expectedBefore) || (result equals expectedBefore) shouldBe true
+    (result isBefore expectedAfter) || (result equals expectedAfter) shouldBe true
   }
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
@@ -94,12 +94,10 @@ class SchedulerInstanceRepositoryTest
   }
 
   "getCurrentDateTime" should "return database current date time" in {
+    val expectedBefore = LocalDateTime.now()
     val result = await(schedulerInstanceRepository.getCurrentDateTime())
-    val expected = LocalDateTime.now()
-    result.getYear shouldBe expected.getYear
-    result.getMonth shouldBe expected.getMonth
-    result.getDayOfWeek shouldBe expected.getDayOfWeek
-    result.getHour shouldBe expected.getHour
-    result.getMinute shouldBe expected.getMinute
+    val expectedAfter = LocalDateTime.now()
+    result isAfter expectedBefore
+    result isBefore expectedAfter
   }
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/persistance/SchedulerInstanceRepositoryTest.scala
@@ -92,4 +92,14 @@ class SchedulerInstanceRepositoryTest
     val result = await(schedulerInstanceRepository.getAllInstances())
     result should contain theSameElementsAs TestData.schedulerInstances
   }
+
+  "getCurrentDateTime" should "return database current date time" in {
+    val result = await(schedulerInstanceRepository.getCurrentDateTime())
+    val expected = LocalDateTime.now()
+    result.getYear shouldBe expected.getYear
+    result.getMonth shouldBe expected.getMonth
+    result.getDayOfWeek shouldBe expected.getDayOfWeek
+    result.getHour shouldBe expected.getHour
+    result.getMinute shouldBe expected.getMinute
+  }
 }

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
@@ -61,7 +61,8 @@ class SchedulerInstanceServiceTest extends AsyncFlatSpec with MockitoSugar with 
       SchedulerInstance(23, SchedulerInstanceStatuses.Active, LocalDateTime.now()),
       SchedulerInstance(24, SchedulerInstanceStatuses.Active, LocalDateTime.now())
     )
-    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext])).thenReturn(Future(LocalDateTime.now()))
+    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext]))
+      .thenReturn(Future(LocalDateTime.now()))
     when(schedulerInstanceRepository.updateHeartbeat(any(), any())(any[ExecutionContext])).thenReturn(Future(1))
     when(schedulerInstanceRepository.getAllInstances()(any[ExecutionContext])).thenReturn(Future(instances))
     when(schedulerInstanceRepository.deactivateLaggingInstances(any(), any(), any())(any[ExecutionContext]))
@@ -82,7 +83,8 @@ class SchedulerInstanceServiceTest extends AsyncFlatSpec with MockitoSugar with 
   it should "throw an exception if the heartbeat could not be updated" in {
     // given
     val lagThreshold = Duration.ofSeconds(5L)
-    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext])).thenReturn(Future(LocalDateTime.now()))
+    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext]))
+      .thenReturn(Future(LocalDateTime.now()))
     when(schedulerInstanceRepository.updateHeartbeat(any(), any())(any[ExecutionContext])).thenReturn(Future(0))
 
     // when

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/scheduler/cluster/SchedulerInstanceServiceTest.scala
@@ -61,6 +61,7 @@ class SchedulerInstanceServiceTest extends AsyncFlatSpec with MockitoSugar with 
       SchedulerInstance(23, SchedulerInstanceStatuses.Active, LocalDateTime.now()),
       SchedulerInstance(24, SchedulerInstanceStatuses.Active, LocalDateTime.now())
     )
+    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext])).thenReturn(Future(LocalDateTime.now()))
     when(schedulerInstanceRepository.updateHeartbeat(any(), any())(any[ExecutionContext])).thenReturn(Future(1))
     when(schedulerInstanceRepository.getAllInstances()(any[ExecutionContext])).thenReturn(Future(instances))
     when(schedulerInstanceRepository.deactivateLaggingInstances(any(), any(), any())(any[ExecutionContext]))
@@ -81,6 +82,7 @@ class SchedulerInstanceServiceTest extends AsyncFlatSpec with MockitoSugar with 
   it should "throw an exception if the heartbeat could not be updated" in {
     // given
     val lagThreshold = Duration.ofSeconds(5L)
+    when(schedulerInstanceRepository.getCurrentDateTime()(any[ExecutionContext])).thenReturn(Future(LocalDateTime.now()))
     when(schedulerInstanceRepository.updateHeartbeat(any(), any())(any[ExecutionContext])).thenReturn(Future(0))
 
     // when


### PR DESCRIPTION
Closes #703

Recognize dead scheduler instances without relying on synchronized clocks