### PR TITLE
#743: Remove testing properties for hyperdrive executor

### DIFF
--- a/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/SchedulerConfig.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/configuration/application/SchedulerConfig.scala
@@ -57,7 +57,5 @@ class Sensors(
 class Executors(
   @NotNull
   @Name("thread.pool.size")
-  val threadPoolSize: Int,
-  @DefaultValue(Array("true"))
-  val enableHyperdriveExecutor: Boolean
+  val threadPoolSize: Int
 )

--- a/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
+++ b/src/main/scala/za/co/absa/hyperdrive/trigger/scheduler/executors/Executors.scala
@@ -115,8 +115,7 @@ class Executors @Inject() (
           jobInstance match {
             case Some(ji) =>
               ji.jobParameters match {
-                case hyperdrive: SparkInstanceParameters
-                    if hyperdrive.jobType == JobTypes.Hyperdrive && useHyperExecutor(hyperdrive) =>
+                case hyperdrive: SparkInstanceParameters if hyperdrive.jobType == JobTypes.Hyperdrive =>
                   HyperdriveExecutor
                     .execute(ji, hyperdrive, updateJob, sparkClusterService, hyperdriveOffsetComparisonService)
                 case spark: SparkInstanceParameters => SparkExecutor.execute(ji, spark, updateJob, sparkClusterService)
@@ -135,12 +134,6 @@ class Executors @Inject() (
         }
         fut
     }
-
-  private def useHyperExecutor(parameters: SparkInstanceParameters) = {
-    schedulerConfig.executors.enableHyperdriveExecutor &&
-    parameters.jobType == JobTypes.Hyperdrive &&
-    parameters.appArguments.contains("useHyperdriveExecutor=true")
-  }
 
   private def updateJob(jobInstance: JobInstance): Future[Unit] = {
     logger.info(

--- a/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestSchedulerConfig.scala
+++ b/src/test/scala/za/co/absa/hyperdrive/trigger/configuration/application/TestSchedulerConfig.scala
@@ -33,6 +33,6 @@ object TestSchedulerConfig {
       autostart,
       lagThreshold,
       new Sensors(sensorsThreadPoolSize, sensorsChangedSensorsChunkQuerySize),
-      new Executors(executorsThreadPoolSize, true)
+      new Executors(executorsThreadPoolSize)
     )
 }


### PR DESCRIPTION
Implements: #743 

_Removed property:_ `scheduler.executors.enableHyperdriveExecutor`
