### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,18 @@
+#
+# Copyright 2018 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 changelog:
   categories:
     - title: All features

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: All features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+          - ignore-for-release
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,14 +14,25 @@
 #
 
 changelog:
+  exclude:
+    labels:
+      - ignore-for-release
   categories:
-    - title: All features
+    - title: Enhancements
       labels:
-        - '*'
-      exclude:
-        labels:
-          - dependencies
-          - ignore-for-release
+        - enhancement
+    - title: Bugfixes
+      labels:
+        - bug        
     - title: Dependencies
       labels:
         - dependencies
+    - title: Uncategorized
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+          - bug
+          - enhancement
+          


### PR DESCRIPTION
Unfortunately, the release.yml works based on the labels of the PR, not the issue. But usually, we only have the label on the issue, not the PR. Therefore, the best I can do is to separate out the dependencies PRs, but I'm not sure if it's worth it.

What do you think?