### PR TITLE
Remove unnecessary tag user input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,6 @@ name: Deploy
 
 on:
   workflow_dispatch:
-    inputs:
-      tag-name:
-        description: 'Tag for deployment (e.g., v0.5.2)'
-        required: true
 
 jobs:
   deploy:
@@ -28,32 +24,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Fetch all history for all tags and branches
-
-      - name: Validate format of received tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const newTag = core.getInput('tag-name');
-            const regex = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
-
-            if (!regex.test(newTag)) {
-              core.setFailed('Tag does not match the required format "v[0-9]+.[0-9]+.[0-9]+". Valid example: v0.5.2');
-              return;
-            }
-          tag-name: ${{ github.event.inputs.tag-name }}
-
-      - name: Define semantic version number
-        id: semantic_version
-        run: |
-          TAG_NAME="${{ github.event.inputs.tag-name }}"
-          VERSION=${TAG_NAME#v}
-          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
-
-      - name: Checkout to tag
-        run: |
-          git checkout ${{ github.event.inputs.tag-name }}
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1


### PR DESCRIPTION
In the "Deploy" action, the tag can be selected with the branch dropdown

![image](https://github.com/AbsaOSS/hyperdrive-trigger/assets/54136196/962adfe6-e4cb-4aa4-aec0-4378c192eee1)

So the user doesn't need to manually type in the tag, which can be error-prone.
